### PR TITLE
Possible to run it public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN chown delegate:delegate ./start.php
 USER delegate
 RUN mkdir config
 ADD delegateBase.conf ./
-ADD proxyList.txt ./
+ADD proxyList.txt ./proxylist/
 ADD anonsquid.conf ./
 ADD Allowed_IP.txt ./
 ADD acl.conf ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN useradd delegate
 WORKDIR /home/delegate
 RUN cp /etc/squid/squid.conf /home/delegate/squid.conf
 RUN chown delegate:delegate /home/delegate/squid.conf
-RUN sed -i '1s/^/acl localnet src 127.0.0.1\/32\n/' /home/delegate/squid.conf
+RUN sed -i '1s/^/acl localnet src 0.0.0.0\/0\n/' /home/delegate/squid.conf
 ADD start.php ./
 RUN chmod +x ./start.php
 RUN chown -R delegate:delegate /var/log/squid/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN useradd delegate
 WORKDIR /home/delegate
 RUN cp /etc/squid/squid.conf /home/delegate/squid.conf
 RUN chown delegate:delegate /home/delegate/squid.conf
-RUN sed -i '1s/^/acl localnet src 0.0.0.0\/0\n/' /home/delegate/squid.conf
+RUN sed -i '1s/^/acl all src 0.0.0.0\/0\n/' /home/delegate/squid.conf
 ADD start.php ./
 RUN chmod +x ./start.php
 RUN chown -R delegate:delegate /var/log/squid/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN useradd delegate
 WORKDIR /home/delegate
 RUN cp /etc/squid/squid.conf /home/delegate/squid.conf
 RUN chown delegate:delegate /home/delegate/squid.conf
-RUN sed -i '1s/^/acl all src 0.0.0.0\/0\n/' /home/delegate/squid.conf
+RUN sed -i '1s/^/acl all src all\n/' /home/delegate/squid.conf
 ADD start.php ./
 RUN chmod +x ./start.php
 RUN chown -R delegate:delegate /var/log/squid/

--- a/README.md
+++ b/README.md
@@ -42,8 +42,15 @@ If you would like to add a huge of http/https proxies,please use :openproxy flag
 
 ## Start docker container
 ```
-docker build -t 39ff/rotate-proxy:1.0 .
-docker run -it -t -d -p127.0.0.1:3128:3128 --name testproxy 39ff/rotate-proxy:1.0
+docker pull confact/rotate-proxy:latest
+docker run -it -t -d -p127.0.0.1:3128:3128 confact/rotate-proxy:latest
+docker exec -it testproxy /bin/bash
+```
+
+want to have your proxylist outside the docker? do this:
+```
+docker pull confact/rotate-proxy:latest
+docker run -it -t -d -p127.0.0.1:3128:3128 -v /home/delegate/proxylist:/proxylist confact/rotate-proxy:latest
 docker exec -it testproxy /bin/bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ IPAddress:Port:Type(socks5 or http or https):Username:Password
 ```
 
 ### proxyList.txt example
-If you would like to add a huge of http/https proxies,please use :openproxy flag that's not use delegate.
+If you would like to add a lot of http/https proxies,please use :openproxy flag that's not use delegate.
 
 ```
 127.0.0.1:1080:socks5:yourUsername:yourPassword
@@ -78,7 +78,7 @@ sh-4.2#
 get a money as rotate proxy provider :)
 
 ## WARN
-USE OF PUBLIC PROXIES WILL BE LEAK A DATA, DO NOT USE LIKE SOCIAL/SHOPPING
+USE OF PUBLIC PROXIES WILL BE LEAKING DATA, DO NOT USE FOR SOCIAL/SHOPPING
 
 ### FIREWALL
 You should have this one behind a firewall or limit access to it as it is setup to allow all access to it.

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ If you would like to add a huge of http/https proxies,please use :openproxy flag
 ## Start docker container
 ```
 docker pull confact/rotate-proxy:latest
-docker run -it -t -d -p127.0.0.1:3128:3128 confact/rotate-proxy:latest
+docker run -it -t -d -p127.0.0.1:3128:3128 --name testproxy confact/rotate-proxy:latest
 docker exec -it testproxy /bin/bash
 ```
 
 want to have your proxylist outside the docker? do this:
 ```
 docker pull confact/rotate-proxy:latest
-docker run -it -t -d -p127.0.0.1:3128:3128 -v /home/delegate/proxylist:/proxylist confact/rotate-proxy:latest
+docker run -it -t -d -p127.0.0.1:3128:3128 -v /home/delegate/proxylist:/proxylist --name testproxy confact/rotate-proxy:latest
 docker exec -it testproxy /bin/bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker exec -it testproxy /bin/bash
 want to have your proxylist outside the docker? do this:
 ```
 docker pull confact/rotate-proxy:latest
-docker run -it -t -d -p127.0.0.1:3128:3128 -v /home/delegate/proxylist:/proxylist --name testproxy confact/rotate-proxy:latest
+docker run -it -t -d -p127.0.0.1:3128:3128 -v /proxylist:/home/delegate/proxylist --name testproxy confact/rotate-proxy:latest
 docker exec -it testproxy /bin/bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ get a money as rotate proxy provider :)
 ## WARN
 USE OF PUBLIC PROXIES WILL BE LEAK A DATA, DO NOT USE LIKE SOCIAL/SHOPPING
 
+### FIREWALL
+You should have this one behind a firewall or limit access to it as it is setup to allow all access to it.
 
 
 ## Why not using Polipo?

--- a/start.php
+++ b/start.php
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php
-$proxies = fopen('/home/delegate/proxyList.txt','r');
+$proxies = fopen('/home/delegate/proxylist/proxyList.txt','r');
 
 $port = 49152;
 $squid = '';


### PR DESCRIPTION
Made it possible to run this in a public setup behind a firewall (like AWS, DO and GC)

this is changed:
* Allow all incoming connection (when we have many other servers connecting to it)
* Moved proxylist to a different directory so it is easy to share that directory and change it outside the container