### PR TITLE
Add native SOCKS4/SOCKS5 support for Squid cache_peer

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/squid-socks
+  IMAGE_NAME: squid-socks
 
 jobs:
   build-and-push:
@@ -46,11 +46,14 @@ jobs:
       - name: Prepare tags
         id: tags
         run: |
-          TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          FULL_IMAGE="${{ env.REGISTRY }}/${OWNER}/${{ env.IMAGE_NAME }}"
+          TAGS="${FULL_IMAGE}:${{ inputs.version }}"
           if [ "${{ inputs.push_latest }}" = "true" ] && [ "${{ inputs.version }}" != "latest" ]; then
-            TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+            TAGS="${TAGS},${FULL_IMAGE}:latest"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "image=${FULL_IMAGE}" >> "$GITHUB_OUTPUT"
           echo "Tags to push: ${TAGS}"
 
       - name: Build and push
@@ -71,6 +74,6 @@ jobs:
 
       - name: Verify pushed image
         run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}
-          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }} squid -v
+          docker pull ${{ steps.tags.outputs.image }}:${{ inputs.version }}
+          docker run --rm ${{ steps.tags.outputs.image }}:${{ inputs.version }} squid -v
           echo "--- Image verification OK ---"

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -1,0 +1,76 @@
+name: Container Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image tag (e.g. v1.0.0, latest)'
+        required: true
+        type: string
+        default: 'latest'
+      push_latest:
+        description: 'Also tag as latest'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/squid-socks
+
+jobs:
+  build-and-push:
+    name: Build & Push Container Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare tags
+        id: tags
+        run: |
+          TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          if [ "${{ inputs.push_latest }}" = "true" ] && [ "${{ inputs.version }}" != "latest" ]; then
+            TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "Tags to push: ${TAGS}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./squid_patch
+          file: ./squid_patch/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.title=squid-socks
+            org.opencontainers.image.description=Squid 6.10 with native SOCKS4/SOCKS5 cache_peer support
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ inputs.version }}
+
+      - name: Verify pushed image
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version }} squid -v
+          echo "--- Image verification OK ---"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.0.0)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          if ! echo "${{ inputs.version }}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "ERROR: Version must match vX.Y.Z or vX.Y.Z-suffix format"
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "refs/tags/${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "ERROR: Tag ${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            echo "Previous tag: ${PREVIOUS_TAG}"
+            CHANGELOG=$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+          else
+            echo "No previous tag found, using full history"
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges -50)
+          fi
+
+          {
+            echo "notes<<EOF"
+            echo "## What's Changed"
+            echo ""
+            echo "${CHANGELOG}"
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...${{ inputs.version }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          name: ${{ inputs.version }}
+          body: ${{ steps.notes.outputs.notes }}
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: false

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -150,10 +150,11 @@ jobs:
       - name: Load image
         run: docker load -i /tmp/squid-image.tar
 
-      - name: Start SOCKS5 test server (microsocks)
+      - name: Start SOCKS5 test server
         run: |
           docker run -d --name socks5-server --network host \
-            ghcr.io/rofl0r/microsocks:latest -p 11080
+            -e PROXY_PORT=11080 \
+            serjs/go-socks5-proxy:latest
           sleep 2
           docker logs socks5-server
 
@@ -217,7 +218,7 @@ jobs:
         run: |
           echo "=== Squid logs ==="
           docker logs squid-test 2>&1 || true
-          echo "=== SOCKS5 server logs ==="
+          echo "=== SOCKS5 test server logs ==="
           docker logs socks5-server 2>&1 || true
 
       - name: Cleanup
@@ -245,10 +246,13 @@ jobs:
       - name: Load image
         run: docker load -i /tmp/squid-image.tar
 
-      - name: Start SOCKS5 server with auth (microsocks)
+      - name: Start SOCKS5 server with auth
         run: |
           docker run -d --name socks5-auth --network host \
-            ghcr.io/rofl0r/microsocks:latest -u testuser -P testpass -p 11081
+            -e PROXY_PORT=11081 \
+            -e PROXY_USER=testuser \
+            -e PROXY_PASSWORD=testpass \
+            serjs/go-socks5-proxy:latest
           sleep 2
 
       - name: Create Squid config with SOCKS5 auth

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -190,37 +190,13 @@ jobs:
           echo "--- Config ---"
           cat /tmp/squid-conf/squid.conf
 
-      - name: Diagnose Squid startup
-        run: |
-          echo "=== Parse test ==="
-          docker run --rm --network host \
-            -v /tmp/squid-conf:/etc/squid/conf.d:ro \
-            --entrypoint squid \
-            ${{ env.SQUID_IMAGE }} \
-            -k parse -f /etc/squid/conf.d/squid.conf 2>&1 || true
-          echo ""
-          echo "=== Dry-run entrypoint ==="
-          docker run --rm --network host \
-            -v /tmp/squid-conf:/etc/squid/conf.d:ro \
-            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
-            --entrypoint /bin/sh \
-            ${{ env.SQUID_IMAGE }} \
-            -c '
-              set -x
-              cat "$SQUID_CONFIG_FILE"
-              squid -z -N -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid -z exit: $?"
-              ls -la /var/cache/squid/ /var/log/squid/ /var/run/squid/ 2>&1
-              chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>&1 || true
-              timeout 5 gosu squid squid -N -X -d5 -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid exit: $?"
-            '
-
       - name: Start Squid with SOCKS5 peer
         run: |
           docker run -d --name squid-test --network host \
             -v /tmp/squid-conf:/etc/squid/conf.d:ro \
             -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
             ${{ env.SQUID_IMAGE }}
-          sleep 3
+          sleep 5
           echo "=== Container status ==="
           docker ps -a --filter name=squid-test --format '{{.Status}}'
           if ! docker ps --filter name=squid-test --filter status=running -q | grep -q .; then
@@ -234,7 +210,7 @@ jobs:
       - name: Wait for Squid to listen
         run: |
           echo "Waiting for Squid to listen on port 3128..."
-          for i in $(seq 1 15); do
+          for i in $(seq 1 30); do
             if bash -c 'echo > /dev/tcp/127.0.0.1/3128' 2>/dev/null; then
               echo "Squid is listening after ${i}s"
               exit 0
@@ -352,28 +328,13 @@ jobs:
           echo "--- Config ---"
           cat /tmp/squid-conf-auth/squid.conf
 
-      - name: Diagnose Squid startup
-        run: |
-          echo "=== Dry-run entrypoint ==="
-          docker run --rm --network host \
-            -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
-            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
-            --entrypoint /bin/sh \
-            ${{ env.SQUID_IMAGE }} \
-            -c '
-              set -x
-              squid -z -N -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid -z exit: $?"
-              chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>&1 || true
-              timeout 5 gosu squid squid -N -X -d5 -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid exit: $?"
-            '
-
       - name: Start Squid with SOCKS5 auth peer
         run: |
           docker run -d --name squid-auth --network host \
             -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
             -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
             ${{ env.SQUID_IMAGE }}
-          sleep 3
+          sleep 5
           echo "=== Container status ==="
           docker ps -a --filter name=squid-auth --format '{{.Status}}'
           if ! docker ps --filter name=squid-auth --filter status=running -q | grep -q .; then
@@ -386,7 +347,7 @@ jobs:
 
       - name: Wait for Squid to listen
         run: |
-          for i in $(seq 1 15); do
+          for i in $(seq 1 30); do
             if bash -c 'echo > /dev/tcp/127.0.0.1/3128' 2>/dev/null; then
               echo "Squid is listening after ${i}s"
               exit 0

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -81,7 +81,6 @@ jobs:
         run: |
           cat > /tmp/squid-socks5.conf <<'CONF'
           http_port 3128
-          acl all src 0.0.0.0/0
           http_access allow all
           never_direct allow all
           cache_peer 127.0.0.1 parent 1080 0 no-query no-digest round-robin proxy-only originserver name=test_socks5 socks5 socks-user=testuser socks-pass=testpass
@@ -98,7 +97,6 @@ jobs:
         run: |
           cat > /tmp/squid-socks4.conf <<'CONF'
           http_port 3128
-          acl all src 0.0.0.0/0
           http_access allow all
           never_direct allow all
           cache_peer 127.0.0.1 parent 1080 0 no-query no-digest round-robin proxy-only originserver name=test_socks4 socks4
@@ -115,7 +113,6 @@ jobs:
         run: |
           cat > /tmp/squid-multi.conf <<'CONF'
           http_port 3128
-          acl all src 0.0.0.0/0
           http_access allow all
           never_direct allow all
           cache_peer 10.0.0.1 parent 1080 0 no-query no-digest round-robin proxy-only originserver name=socks1 socks5 socks-user=user1 socks-pass=pass1
@@ -177,7 +174,6 @@ jobs:
           mkdir -p /tmp/squid-conf
           cat > /tmp/squid-conf/squid.conf <<CONF
           http_port 3128
-          acl all src 0.0.0.0/0
           http_access allow all
           never_direct allow all
           server_persistent_connections off
@@ -185,23 +181,18 @@ jobs:
           cache_peer 127.0.0.1 parent 11080 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_test socks5
           visible_hostname test
           cache deny all
-          access_log stdio:/proc/self/fd/1 combined
+          cache_log /var/log/squid/cache.log
+          access_log stdio:/var/log/squid/access.log combined
           CONF
           echo "--- Config ---"
           cat /tmp/squid-conf/squid.conf
 
       - name: Start Squid with SOCKS5 peer
         run: |
-          # Bypass entrypoint - run squid directly to isolate issues
           docker run -d --name squid-test --network host \
             -v /tmp/squid-conf:/etc/squid/conf.d:ro \
-            --entrypoint /bin/sh \
-            ${{ env.SQUID_IMAGE }} \
-            -c '
-              squid -z -N -f /etc/squid/conf.d/squid.conf 2>&1 || true
-              echo "=== Starting Squid ==="
-              exec squid -N -f /etc/squid/conf.d/squid.conf 2>&1
-            '
+            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
+            ${{ env.SQUID_IMAGE }}
           sleep 5
           echo "=== Container status ==="
           docker ps -a --filter name=squid-test --format '{{.Status}}'
@@ -337,7 +328,6 @@ jobs:
           mkdir -p /tmp/squid-conf-auth
           cat > /tmp/squid-conf-auth/squid.conf <<CONF
           http_port 3128
-          acl all src 0.0.0.0/0
           http_access allow all
           never_direct allow all
           server_persistent_connections off
@@ -345,7 +335,8 @@ jobs:
           cache_peer 127.0.0.1 parent 11081 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_auth socks5 socks-user=testuser socks-pass=testpass
           visible_hostname test
           cache deny all
-          access_log stdio:/proc/self/fd/1 combined
+          cache_log /var/log/squid/cache.log
+          access_log stdio:/var/log/squid/access.log combined
           CONF
           echo "--- Config ---"
           cat /tmp/squid-conf-auth/squid.conf
@@ -354,13 +345,8 @@ jobs:
         run: |
           docker run -d --name squid-auth --network host \
             -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
-            --entrypoint /bin/sh \
-            ${{ env.SQUID_IMAGE }} \
-            -c '
-              squid -z -N -f /etc/squid/conf.d/squid.conf 2>&1 || true
-              echo "=== Starting Squid ==="
-              exec squid -N -f /etc/squid/conf.d/squid.conf 2>&1
-            '
+            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
+            ${{ env.SQUID_IMAGE }}
           sleep 5
           echo "=== Container status ==="
           docker ps -a --filter name=squid-auth --format '{{.Status}}'

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -181,6 +181,7 @@ jobs:
           cache_peer 127.0.0.1 parent 11080 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_test socks5
           visible_hostname test
           cache deny all
+          pid_filename /var/run/squid/squid.pid
           cache_log /var/log/squid/cache.log
           access_log stdio:/var/log/squid/access.log combined
           CONF
@@ -335,6 +336,7 @@ jobs:
           cache_peer 127.0.0.1 parent 11081 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_auth socks5 socks-user=testuser socks-pass=testpass
           visible_hostname test
           cache deny all
+          pid_filename /var/run/squid/squid.pid
           cache_log /var/log/squid/cache.log
           access_log stdio:/var/log/squid/access.log combined
           CONF

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -206,36 +206,60 @@ jobs:
           fi
           echo "=== Early Squid logs ==="
           docker logs squid-test 2>&1 || true
-          echo "Waiting for Squid to accept connections..."
-          READY=0
-          for i in $(seq 1 30); do
-            if curl -sf -o /dev/null -w '%{http_code}' -x http://127.0.0.1:3128 http://127.0.0.1:18080/ip 2>/dev/null; then
-              echo "Squid is ready after ${i}s"
-              READY=1
-              break
+
+      - name: Wait for Squid to listen
+        run: |
+          echo "Waiting for Squid to listen on port 3128..."
+          for i in $(seq 1 15); do
+            if bash -c 'echo > /dev/tcp/127.0.0.1/3128' 2>/dev/null; then
+              echo "Squid is listening after ${i}s"
+              exit 0
             fi
             sleep 1
           done
-          if [ "$READY" -eq 0 ]; then
-            echo "ERROR: Squid failed to respond within 30 seconds"
-            docker logs squid-test 2>&1 || true
-            exit 1
-          fi
+          echo "ERROR: Squid never started listening"
+          docker logs squid-test 2>&1 || true
+          exit 1
+
+      - name: Verify HTTP server is still up
+        run: curl -sf http://127.0.0.1:18080/ip
 
       - name: Test HTTP request through SOCKS5 peer
         run: |
-          RESPONSE=$(curl -v -x http://127.0.0.1:3128 http://127.0.0.1:18080/ip 2>&1)
-          echo "Response: ${RESPONSE}"
-          echo "${RESPONSE}" | grep -q "test" || { echo "FAIL: unexpected response"; exit 1; }
+          echo "--- Attempting proxy request ---"
+          HTTP_CODE=$(curl -s -o /tmp/proxy-response.txt -w '%{http_code}' --max-time 15 -x http://127.0.0.1:3128 http://127.0.0.1:18080/ip 2>/tmp/proxy-stderr.txt || true)
+          echo "HTTP status: ${HTTP_CODE}"
+          echo "Response body:"
+          cat /tmp/proxy-response.txt || true
+          echo ""
+          echo "Curl stderr:"
+          cat /tmp/proxy-stderr.txt || true
+          echo ""
+          echo "=== Squid logs after request ==="
+          docker logs squid-test 2>&1 | tail -30 || true
+          echo ""
+          # Now assert
+          [ "${HTTP_CODE}" = "200" ] || { echo "FAIL: expected 200, got ${HTTP_CODE}"; exit 1; }
+          grep -q "test" /tmp/proxy-response.txt || { echo "FAIL: unexpected response body"; exit 1; }
           echo "--- HTTP via SOCKS5 OK ---"
 
-      - name: Show Squid logs on failure
-        if: failure()
+      - name: Collect logs
+        if: always()
         run: |
-          echo "=== Squid logs ==="
-          docker logs squid-test 2>&1 || true
-          echo "=== SOCKS5 test server logs ==="
-          docker logs socks5-server 2>&1 || true
+          mkdir -p /tmp/test-logs
+          docker logs squid-test > /tmp/test-logs/squid.log 2>&1 || true
+          docker logs socks5-server > /tmp/test-logs/socks5.log 2>&1 || true
+          cp /tmp/squid-conf/squid.conf /tmp/test-logs/ 2>/dev/null || true
+          cp /tmp/proxy-response.txt /tmp/test-logs/ 2>/dev/null || true
+          cp /tmp/proxy-stderr.txt /tmp/test-logs/ 2>/dev/null || true
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-logs
+          path: /tmp/test-logs/
+          retention-days: 3
 
       - name: Cleanup
         if: always()
@@ -320,36 +344,58 @@ jobs:
           fi
           echo "=== Early Squid logs ==="
           docker logs squid-auth 2>&1 || true
-          echo "Waiting for Squid to accept connections..."
-          READY=0
-          for i in $(seq 1 30); do
-            if curl -sf -o /dev/null -w '%{http_code}' -x http://127.0.0.1:3128 http://127.0.0.1:18081/ip 2>/dev/null; then
-              echo "Squid ready after ${i}s"
-              READY=1
-              break
+
+      - name: Wait for Squid to listen
+        run: |
+          for i in $(seq 1 15); do
+            if bash -c 'echo > /dev/tcp/127.0.0.1/3128' 2>/dev/null; then
+              echo "Squid is listening after ${i}s"
+              exit 0
             fi
             sleep 1
           done
-          if [ "$READY" -eq 0 ]; then
-            echo "ERROR: Squid failed to respond within 30 seconds"
-            docker logs squid-auth 2>&1 || true
-            exit 1
-          fi
+          echo "ERROR: Squid never started listening"
+          docker logs squid-auth 2>&1 || true
+          exit 1
+
+      - name: Verify HTTP server is still up
+        run: curl -sf http://127.0.0.1:18081/ip
 
       - name: Test HTTP through authenticated SOCKS5
         run: |
-          RESPONSE=$(curl -v -x http://127.0.0.1:3128 http://127.0.0.1:18081/ip 2>&1)
-          echo "Response: ${RESPONSE}"
-          echo "${RESPONSE}" | grep -q "test" || { echo "FAIL"; exit 1; }
+          echo "--- Attempting proxy request ---"
+          HTTP_CODE=$(curl -s -o /tmp/proxy-response.txt -w '%{http_code}' --max-time 15 -x http://127.0.0.1:3128 http://127.0.0.1:18081/ip 2>/tmp/proxy-stderr.txt || true)
+          echo "HTTP status: ${HTTP_CODE}"
+          echo "Response body:"
+          cat /tmp/proxy-response.txt || true
+          echo ""
+          echo "Curl stderr:"
+          cat /tmp/proxy-stderr.txt || true
+          echo ""
+          echo "=== Squid logs after request ==="
+          docker logs squid-auth 2>&1 | tail -30 || true
+          echo ""
+          [ "${HTTP_CODE}" = "200" ] || { echo "FAIL: expected 200, got ${HTTP_CODE}"; exit 1; }
+          grep -q "test" /tmp/proxy-response.txt || { echo "FAIL: unexpected body"; exit 1; }
           echo "--- HTTP via SOCKS5 auth OK ---"
 
-      - name: Show logs on failure
-        if: failure()
+      - name: Collect logs
+        if: always()
         run: |
-          echo "=== Squid logs ==="
-          docker logs squid-auth 2>&1 || true
-          echo "=== SOCKS5 auth server logs ==="
-          docker logs socks5-auth 2>&1 || true
+          mkdir -p /tmp/test-logs-auth
+          docker logs squid-auth > /tmp/test-logs-auth/squid.log 2>&1 || true
+          docker logs socks5-auth > /tmp/test-logs-auth/socks5.log 2>&1 || true
+          cp /tmp/squid-conf-auth/squid.conf /tmp/test-logs-auth/ 2>/dev/null || true
+          cp /tmp/proxy-response.txt /tmp/test-logs-auth/ 2>/dev/null || true
+          cp /tmp/proxy-stderr.txt /tmp/test-logs-auth/ 2>/dev/null || true
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: auth-test-logs
+          path: /tmp/test-logs-auth/
+          retention-days: 3
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -183,13 +183,20 @@ jobs:
             -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
             ${{ env.SQUID_IMAGE }}
           echo "Waiting for Squid to start..."
-          for i in $(seq 1 15); do
+          READY=0
+          for i in $(seq 1 30); do
             if curl -sf -x http://127.0.0.1:3128 -o /dev/null http://httpbin.org/ip 2>/dev/null; then
               echo "Squid is ready after ${i}s"
+              READY=1
               break
             fi
             sleep 1
           done
+          if [ "$READY" -eq 0 ]; then
+            echo "ERROR: Squid failed to start within 30 seconds"
+            docker logs squid-test 2>&1 || true
+            exit 1
+          fi
 
       - name: Test HTTP request through SOCKS5 peer
         run: |
@@ -269,13 +276,20 @@ jobs:
             -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
             -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
             ${{ env.SQUID_IMAGE }}
-          for i in $(seq 1 15); do
+          READY=0
+          for i in $(seq 1 30); do
             if curl -sf -x http://127.0.0.1:3128 -o /dev/null http://httpbin.org/ip 2>/dev/null; then
               echo "Squid ready after ${i}s"
+              READY=1
               break
             fi
             sleep 1
           done
+          if [ "$READY" -eq 0 ]; then
+            echo "ERROR: Squid failed to start within 30 seconds"
+            docker logs squid-auth 2>&1 || true
+            exit 1
+          fi
 
       - name: Test HTTP through authenticated SOCKS5
         run: |

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -249,6 +249,22 @@ jobs:
           grep -q "test" /tmp/proxy-response.txt || { echo "FAIL: unexpected response body"; exit 1; }
           echo "--- HTTP via SOCKS5 OK ---"
 
+      - name: Post Squid logs to PR on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            let logs = '';
+            try { logs = execSync('docker logs squid-test 2>&1', {encoding: 'utf8', maxBuffer: 50*1024}); } catch(e) { logs = e.stdout || e.message; }
+            const body = `### E2E Test Squid Logs\n\`\`\`\n${logs.slice(-3000)}\n\`\`\``;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 30,
+              body: body
+            });
+
       - name: Collect logs
         if: always()
         run: |
@@ -389,6 +405,22 @@ jobs:
           [ "${HTTP_CODE}" = "200" ] || { echo "FAIL: expected 200, got ${HTTP_CODE}"; exit 1; }
           grep -q "test" /tmp/proxy-response.txt || { echo "FAIL: unexpected body"; exit 1; }
           echo "--- HTTP via SOCKS5 auth OK ---"
+
+      - name: Post Squid logs to PR on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            let logs = '';
+            try { logs = execSync('docker logs squid-auth 2>&1', {encoding: 'utf8', maxBuffer: 50*1024}); } catch(e) { logs = e.stdout || e.message; }
+            const body = `### Auth Test Squid Logs\n\`\`\`\n${logs.slice(-3000)}\n\`\`\``;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 30,
+              body: body
+            });
 
       - name: Collect logs
         if: always()

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -159,18 +159,18 @@ jobs:
           curl -sf http://127.0.0.1:18080/ip
           echo "--- Local HTTP server ready ---"
 
-      - name: Start SOCKS5 test server
+      - name: Build and start SOCKS5 test server (microsocks)
         run: |
-          docker run -d --name socks5-server --network host \
-            -e PROXY_PORT=11080 \
-            serjs/go-socks5-proxy:latest
-          sleep 2
-          docker logs socks5-server
+          git clone --depth 1 https://github.com/rofl0r/microsocks.git /tmp/microsocks
+          cd /tmp/microsocks && make -j"$(nproc)"
+          /tmp/microsocks/microsocks -p 11080 &
+          sleep 1
           echo "--- Verify SOCKS5 server directly ---"
           curl -sf --socks5-hostname 127.0.0.1:11080 http://127.0.0.1:18080/ip || {
             echo "ERROR: SOCKS5 server not working"
             exit 1
           }
+          echo "--- SOCKS5 server OK ---"
 
       - name: Create Squid config for SOCKS5 peer
         run: |
@@ -248,7 +248,6 @@ jobs:
         run: |
           mkdir -p /tmp/test-logs
           docker logs squid-test > /tmp/test-logs/squid.log 2>&1 || true
-          docker logs socks5-server > /tmp/test-logs/socks5.log 2>&1 || true
           cp /tmp/squid-conf/squid.conf /tmp/test-logs/ 2>/dev/null || true
           cp /tmp/proxy-response.txt /tmp/test-logs/ 2>/dev/null || true
           cp /tmp/proxy-stderr.txt /tmp/test-logs/ 2>/dev/null || true
@@ -264,7 +263,8 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker rm -f squid-test socks5-server 2>/dev/null || true
+          docker rm -f squid-test 2>/dev/null || true
+          pkill microsocks 2>/dev/null || true
           kill %1 2>/dev/null || true
 
   # ------------------------------------------------------------------
@@ -295,20 +295,20 @@ jobs:
           sleep 1
           curl -sf http://127.0.0.1:18081/ip
 
-      - name: Start SOCKS5 server with auth
+      - name: Build and start SOCKS5 server with auth (microsocks)
         run: |
-          docker run -d --name socks5-auth --network host \
-            -e PROXY_PORT=11081 \
-            -e PROXY_USER=testuser \
-            -e PROXY_PASSWORD=testpass \
-            serjs/go-socks5-proxy:latest
-          sleep 2
-          docker logs socks5-auth
+          if [ ! -f /tmp/microsocks/microsocks ]; then
+            git clone --depth 1 https://github.com/rofl0r/microsocks.git /tmp/microsocks
+            cd /tmp/microsocks && make -j"$(nproc)"
+          fi
+          /tmp/microsocks/microsocks -u testuser -P testpass -p 11081 &
+          sleep 1
           echo "--- Verify SOCKS5 auth server directly ---"
           curl -sf --socks5-hostname testuser:testpass@127.0.0.1:11081 http://127.0.0.1:18081/ip || {
             echo "ERROR: SOCKS5 auth server not working"
             exit 1
           }
+          echo "--- SOCKS5 auth server OK ---"
 
       - name: Create Squid config with SOCKS5 auth
         run: |
@@ -384,7 +384,6 @@ jobs:
         run: |
           mkdir -p /tmp/test-logs-auth
           docker logs squid-auth > /tmp/test-logs-auth/squid.log 2>&1 || true
-          docker logs socks5-auth > /tmp/test-logs-auth/socks5.log 2>&1 || true
           cp /tmp/squid-conf-auth/squid.conf /tmp/test-logs-auth/ 2>/dev/null || true
           cp /tmp/proxy-response.txt /tmp/test-logs-auth/ 2>/dev/null || true
           cp /tmp/proxy-stderr.txt /tmp/test-logs-auth/ 2>/dev/null || true
@@ -400,7 +399,8 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker rm -f squid-auth socks5-auth 2>/dev/null || true
+          docker rm -f squid-auth 2>/dev/null || true
+          pkill microsocks 2>/dev/null || true
           kill %1 2>/dev/null || true
 
   # ------------------------------------------------------------------

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -192,10 +192,16 @@ jobs:
 
       - name: Start Squid with SOCKS5 peer
         run: |
+          # Bypass entrypoint - run squid directly to isolate issues
           docker run -d --name squid-test --network host \
             -v /tmp/squid-conf:/etc/squid/conf.d:ro \
-            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
-            ${{ env.SQUID_IMAGE }}
+            --entrypoint /bin/sh \
+            ${{ env.SQUID_IMAGE }} \
+            -c '
+              squid -z -N -f /etc/squid/conf.d/squid.conf 2>&1 || true
+              echo "=== Starting Squid ==="
+              exec squid -N -f /etc/squid/conf.d/squid.conf 2>&1
+            '
           sleep 5
           echo "=== Container status ==="
           docker ps -a --filter name=squid-test --format '{{.Status}}'
@@ -332,8 +338,13 @@ jobs:
         run: |
           docker run -d --name squid-auth --network host \
             -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
-            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
-            ${{ env.SQUID_IMAGE }}
+            --entrypoint /bin/sh \
+            ${{ env.SQUID_IMAGE }} \
+            -c '
+              squid -z -N -f /etc/squid/conf.d/squid.conf 2>&1 || true
+              echo "=== Starting Squid ==="
+              exec squid -N -f /etc/squid/conf.d/squid.conf 2>&1
+            '
           sleep 5
           echo "=== Container status ==="
           docker ps -a --filter name=squid-auth --format '{{.Status}}'

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -190,6 +190,30 @@ jobs:
           echo "--- Config ---"
           cat /tmp/squid-conf/squid.conf
 
+      - name: Diagnose Squid startup
+        run: |
+          echo "=== Parse test ==="
+          docker run --rm --network host \
+            -v /tmp/squid-conf:/etc/squid/conf.d:ro \
+            --entrypoint squid \
+            ${{ env.SQUID_IMAGE }} \
+            -k parse -f /etc/squid/conf.d/squid.conf 2>&1 || true
+          echo ""
+          echo "=== Dry-run entrypoint ==="
+          docker run --rm --network host \
+            -v /tmp/squid-conf:/etc/squid/conf.d:ro \
+            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
+            --entrypoint /bin/sh \
+            ${{ env.SQUID_IMAGE }} \
+            -c '
+              set -x
+              cat "$SQUID_CONFIG_FILE"
+              squid -z -N -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid -z exit: $?"
+              ls -la /var/cache/squid/ /var/log/squid/ /var/run/squid/ 2>&1
+              chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>&1 || true
+              timeout 5 gosu squid squid -N -X -d5 -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid exit: $?"
+            '
+
       - name: Start Squid with SOCKS5 peer
         run: |
           docker run -d --name squid-test --network host \
@@ -327,6 +351,21 @@ jobs:
           CONF
           echo "--- Config ---"
           cat /tmp/squid-conf-auth/squid.conf
+
+      - name: Diagnose Squid startup
+        run: |
+          echo "=== Dry-run entrypoint ==="
+          docker run --rm --network host \
+            -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
+            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
+            --entrypoint /bin/sh \
+            ${{ env.SQUID_IMAGE }} \
+            -c '
+              set -x
+              squid -z -N -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid -z exit: $?"
+              chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>&1 || true
+              timeout 5 gosu squid squid -N -X -d5 -f "$SQUID_CONFIG_FILE" 2>&1 || echo "squid exit: $?"
+            '
 
       - name: Start Squid with SOCKS5 auth peer
         run: |

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -445,6 +445,140 @@ jobs:
           pkill -f 'python3 -m http.server' 2>/dev/null || true
 
   # ------------------------------------------------------------------
+  # 4b. Test: SOCKS5 connection reuse / no cross-target routing
+  #     Regression for codex P1/P2: a SOCKS tunnel bound to target X must
+  #     never be reused for target Y, even with server pconns ENABLED.
+  # ------------------------------------------------------------------
+  test-socks5-reuse:
+    name: Test SOCKS5 No Cross-Target Reuse
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: squid-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load -i /tmp/squid-image.tar
+
+      - name: Start two distinct origin servers (A and B)
+        run: |
+          mkdir -p /tmp/wwwA /tmp/wwwB
+          echo 'ORIGIN-AAAA' > /tmp/wwwA/ip
+          echo 'ORIGIN-BBBB' > /tmp/wwwB/ip
+          python3 -m http.server 18090 --directory /tmp/wwwA &
+          python3 -m http.server 18091 --directory /tmp/wwwB &
+          sleep 1
+          curl -sf http://127.0.0.1:18090/ip | grep -q ORIGIN-AAAA
+          curl -sf http://127.0.0.1:18091/ip | grep -q ORIGIN-BBBB
+          echo "--- Origins A/B ready ---"
+
+      - name: Build and start SOCKS5 test server (microsocks)
+        run: |
+          if [ ! -f /tmp/microsocks/microsocks ]; then
+            git clone --depth 1 https://github.com/rofl0r/microsocks.git /tmp/microsocks
+            cd /tmp/microsocks && make -j"$(nproc)"
+          fi
+          /tmp/microsocks/microsocks -p 11090 &
+          sleep 1
+          curl -sf --socks5-hostname 127.0.0.1:11090 http://127.0.0.1:18090/ip | grep -q ORIGIN-AAAA
+          curl -sf --socks5-hostname 127.0.0.1:11090 http://127.0.0.1:18091/ip | grep -q ORIGIN-BBBB
+          echo "--- SOCKS5 server reaches both origins ---"
+
+      - name: Create Squid config with server pconns ENABLED
+        run: |
+          mkdir -p /tmp/squid-conf-reuse
+          cat > /tmp/squid-conf-reuse/squid.conf <<CONF
+          http_port 3128
+          http_access allow all
+          never_direct allow all
+          server_persistent_connections on
+          client_persistent_connections on
+          cache_peer 127.0.0.1 parent 11090 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_reuse socks5
+          visible_hostname test
+          cache deny all
+          pid_filename /var/run/squid/squid.pid
+          cache_log /var/log/squid/cache.log
+          access_log stdio:/var/log/squid/access.log combined
+          CONF
+          echo "--- Config (server_persistent_connections ON) ---"
+          cat /tmp/squid-conf-reuse/squid.conf
+
+      - name: Start Squid
+        run: |
+          docker run -d --name squid-reuse --network host \
+            -v /tmp/squid-conf-reuse:/etc/squid/conf.d:ro \
+            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
+            ${{ env.SQUID_IMAGE }}
+          sleep 5
+          if ! docker ps --filter name=squid-reuse --filter status=running -q | grep -q .; then
+            echo "ERROR: Squid container is not running"
+            docker logs squid-reuse 2>&1 || true
+            exit 1
+          fi
+
+      - name: Wait for Squid to listen
+        run: |
+          for i in $(seq 1 30); do
+            if bash -c 'echo > /dev/tcp/127.0.0.1/3128' 2>/dev/null; then
+              echo "Squid is listening after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: Squid never started listening"
+          docker logs squid-reuse 2>&1 || true
+          exit 1
+
+      - name: Alternate A/B requests and assert no cross-target reuse
+        run: |
+          fail=0
+          for i in 1 2 3 4; do
+            RA=$(curl -s --max-time 15 -x http://127.0.0.1:3128 http://127.0.0.1:18090/ip || true)
+            RB=$(curl -s --max-time 15 -x http://127.0.0.1:3128 http://127.0.0.1:18091/ip || true)
+            echo "iter ${i}: A='${RA}' B='${RB}'"
+            echo "${RA}" | grep -q 'ORIGIN-AAAA' || { echo "FAIL: target A returned '${RA}'"; fail=1; }
+            echo "${RB}" | grep -q 'ORIGIN-BBBB' || { echo "FAIL: cross-target reuse! target B returned '${RB}'"; fail=1; }
+          done
+          echo "=== Squid logs ==="
+          docker logs squid-reuse 2>&1 | tail -40 || true
+          [ "${fail}" -eq 0 ] || { echo "--- Cross-target reuse detected ---"; exit 1; }
+          echo "--- No cross-target reuse: OK ---"
+
+      - name: Post Squid logs to PR on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            let logs = '';
+            try { logs = execSync('docker logs squid-reuse 2>&1', {encoding: 'utf8', maxBuffer: 50*1024}); } catch(e) { logs = e.stdout || e.message; }
+            const body = `### Reuse Test Squid Logs\n\`\`\`\n${logs.slice(-3000)}\n\`\`\``;
+            const issueNumber = context.issue.number;
+            if (!issueNumber) {
+              console.log('No PR context; skipping comment.');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: body
+              });
+            }
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f squid-reuse 2>/dev/null || true
+          pkill microsocks 2>/dev/null || true
+          pkill -f 'python3 -m http.server' 2>/dev/null || true
+
+  # ------------------------------------------------------------------
   # 5. Test: generate.php produces correct config
   # ------------------------------------------------------------------
   test-generate:

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -284,7 +284,7 @@ jobs:
         run: |
           docker rm -f squid-test 2>/dev/null || true
           pkill microsocks 2>/dev/null || true
-          kill %1 2>/dev/null || true
+          pkill -f 'python3 -m http.server' 2>/dev/null || true
 
   # ------------------------------------------------------------------
   # 4. Test: SOCKS5 with authentication
@@ -442,7 +442,7 @@ jobs:
         run: |
           docker rm -f squid-auth 2>/dev/null || true
           pkill microsocks 2>/dev/null || true
-          kill %1 2>/dev/null || true
+          pkill -f 'python3 -m http.server' 2>/dev/null || true
 
   # ------------------------------------------------------------------
   # 5. Test: generate.php produces correct config

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -250,12 +250,17 @@ jobs:
             let logs = '';
             try { logs = execSync('docker logs squid-test 2>&1', {encoding: 'utf8', maxBuffer: 50*1024}); } catch(e) { logs = e.stdout || e.message; }
             const body = `### E2E Test Squid Logs\n\`\`\`\n${logs.slice(-3000)}\n\`\`\``;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: 30,
-              body: body
-            });
+            const issueNumber = context.issue.number;
+            if (!issueNumber) {
+              console.log('No PR context; skipping comment.');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: body
+              });
+            }
 
       - name: Collect logs
         if: always()
@@ -403,12 +408,17 @@ jobs:
             let logs = '';
             try { logs = execSync('docker logs squid-auth 2>&1', {encoding: 'utf8', maxBuffer: 50*1024}); } catch(e) { logs = e.stdout || e.message; }
             const body = `### Auth Test Squid Logs\n\`\`\`\n${logs.slice(-3000)}\n\`\`\``;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: 30,
-              body: body
-            });
+            const issueNumber = context.issue.number;
+            if (!issueNumber) {
+              console.log('No PR context; skipping comment.');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: body
+              });
+            }
 
       - name: Collect logs
         if: always()

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -150,6 +150,15 @@ jobs:
       - name: Load image
         run: docker load -i /tmp/squid-image.tar
 
+      - name: Start local HTTP test server
+        run: |
+          mkdir -p /tmp/www
+          echo '{"origin":"127.0.0.1","test":"ok"}' > /tmp/www/ip
+          python3 -m http.server 18080 --directory /tmp/www &
+          sleep 1
+          curl -sf http://127.0.0.1:18080/ip
+          echo "--- Local HTTP server ready ---"
+
       - name: Start SOCKS5 test server
         run: |
           docker run -d --name socks5-server --network host \
@@ -157,11 +166,16 @@ jobs:
             serjs/go-socks5-proxy:latest
           sleep 2
           docker logs socks5-server
+          echo "--- Verify SOCKS5 server directly ---"
+          curl -sf --socks5-hostname 127.0.0.1:11080 http://127.0.0.1:18080/ip || {
+            echo "ERROR: SOCKS5 server not working"
+            exit 1
+          }
 
       - name: Create Squid config for SOCKS5 peer
         run: |
           mkdir -p /tmp/squid-conf
-          cat > /tmp/squid-conf/squid.conf <<'CONF'
+          cat > /tmp/squid-conf/squid.conf <<CONF
           http_port 3128
           acl all src 0.0.0.0/0
           http_access allow all
@@ -170,12 +184,11 @@ jobs:
           client_persistent_connections off
           cache_peer 127.0.0.1 parent 11080 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_test socks5
           visible_hostname test
+          cache deny all
           access_log stdio:/proc/self/fd/1 combined
           CONF
-
-          cat > /tmp/squid-conf/allowed_ip.txt <<'ALLOW'
-          0.0.0.0/0
-          ALLOW
+          echo "--- Config ---"
+          cat /tmp/squid-conf/squid.conf
 
       - name: Start Squid with SOCKS5 peer
         run: |
@@ -183,10 +196,20 @@ jobs:
             -v /tmp/squid-conf:/etc/squid/conf.d:ro \
             -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
             ${{ env.SQUID_IMAGE }}
-          echo "Waiting for Squid to start..."
+          sleep 3
+          echo "=== Container status ==="
+          docker ps -a --filter name=squid-test --format '{{.Status}}'
+          if ! docker ps --filter name=squid-test --filter status=running -q | grep -q .; then
+            echo "ERROR: Squid container is not running"
+            docker logs squid-test 2>&1 || true
+            exit 1
+          fi
+          echo "=== Early Squid logs ==="
+          docker logs squid-test 2>&1 || true
+          echo "Waiting for Squid to accept connections..."
           READY=0
           for i in $(seq 1 30); do
-            if curl -sf -x http://127.0.0.1:3128 -o /dev/null http://httpbin.org/ip 2>/dev/null; then
+            if curl -sf -o /dev/null -w '%{http_code}' -x http://127.0.0.1:3128 http://127.0.0.1:18080/ip 2>/dev/null; then
               echo "Squid is ready after ${i}s"
               READY=1
               break
@@ -194,24 +217,17 @@ jobs:
             sleep 1
           done
           if [ "$READY" -eq 0 ]; then
-            echo "ERROR: Squid failed to start within 30 seconds"
+            echo "ERROR: Squid failed to respond within 30 seconds"
             docker logs squid-test 2>&1 || true
             exit 1
           fi
 
       - name: Test HTTP request through SOCKS5 peer
         run: |
-          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 http://httpbin.org/ip)
+          RESPONSE=$(curl -v -x http://127.0.0.1:3128 http://127.0.0.1:18080/ip 2>&1)
           echo "Response: ${RESPONSE}"
-          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL: unexpected response"; exit 1; }
+          echo "${RESPONSE}" | grep -q "test" || { echo "FAIL: unexpected response"; exit 1; }
           echo "--- HTTP via SOCKS5 OK ---"
-
-      - name: Test HTTPS request through SOCKS5 peer
-        run: |
-          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 https://httpbin.org/ip)
-          echo "Response: ${RESPONSE}"
-          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL: unexpected response"; exit 1; }
-          echo "--- HTTPS via SOCKS5 OK ---"
 
       - name: Show Squid logs on failure
         if: failure()
@@ -225,6 +241,7 @@ jobs:
         if: always()
         run: |
           docker rm -f squid-test socks5-server 2>/dev/null || true
+          kill %1 2>/dev/null || true
 
   # ------------------------------------------------------------------
   # 4. Test: SOCKS5 with authentication
@@ -246,6 +263,14 @@ jobs:
       - name: Load image
         run: docker load -i /tmp/squid-image.tar
 
+      - name: Start local HTTP test server
+        run: |
+          mkdir -p /tmp/www
+          echo '{"origin":"127.0.0.1","test":"ok"}' > /tmp/www/ip
+          python3 -m http.server 18081 --directory /tmp/www &
+          sleep 1
+          curl -sf http://127.0.0.1:18081/ip
+
       - name: Start SOCKS5 server with auth
         run: |
           docker run -d --name socks5-auth --network host \
@@ -254,11 +279,17 @@ jobs:
             -e PROXY_PASSWORD=testpass \
             serjs/go-socks5-proxy:latest
           sleep 2
+          docker logs socks5-auth
+          echo "--- Verify SOCKS5 auth server directly ---"
+          curl -sf --socks5-hostname testuser:testpass@127.0.0.1:11081 http://127.0.0.1:18081/ip || {
+            echo "ERROR: SOCKS5 auth server not working"
+            exit 1
+          }
 
       - name: Create Squid config with SOCKS5 auth
         run: |
           mkdir -p /tmp/squid-conf-auth
-          cat > /tmp/squid-conf-auth/squid.conf <<'CONF'
+          cat > /tmp/squid-conf-auth/squid.conf <<CONF
           http_port 3128
           acl all src 0.0.0.0/0
           http_access allow all
@@ -267,12 +298,11 @@ jobs:
           client_persistent_connections off
           cache_peer 127.0.0.1 parent 11081 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_auth socks5 socks-user=testuser socks-pass=testpass
           visible_hostname test
+          cache deny all
           access_log stdio:/proc/self/fd/1 combined
           CONF
-
-          cat > /tmp/squid-conf-auth/allowed_ip.txt <<'ALLOW'
-          0.0.0.0/0
-          ALLOW
+          echo "--- Config ---"
+          cat /tmp/squid-conf-auth/squid.conf
 
       - name: Start Squid with SOCKS5 auth peer
         run: |
@@ -280,9 +310,20 @@ jobs:
             -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
             -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
             ${{ env.SQUID_IMAGE }}
+          sleep 3
+          echo "=== Container status ==="
+          docker ps -a --filter name=squid-auth --format '{{.Status}}'
+          if ! docker ps --filter name=squid-auth --filter status=running -q | grep -q .; then
+            echo "ERROR: Squid container is not running"
+            docker logs squid-auth 2>&1 || true
+            exit 1
+          fi
+          echo "=== Early Squid logs ==="
+          docker logs squid-auth 2>&1 || true
+          echo "Waiting for Squid to accept connections..."
           READY=0
           for i in $(seq 1 30); do
-            if curl -sf -x http://127.0.0.1:3128 -o /dev/null http://httpbin.org/ip 2>/dev/null; then
+            if curl -sf -o /dev/null -w '%{http_code}' -x http://127.0.0.1:3128 http://127.0.0.1:18081/ip 2>/dev/null; then
               echo "Squid ready after ${i}s"
               READY=1
               break
@@ -290,24 +331,17 @@ jobs:
             sleep 1
           done
           if [ "$READY" -eq 0 ]; then
-            echo "ERROR: Squid failed to start within 30 seconds"
+            echo "ERROR: Squid failed to respond within 30 seconds"
             docker logs squid-auth 2>&1 || true
             exit 1
           fi
 
       - name: Test HTTP through authenticated SOCKS5
         run: |
-          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 http://httpbin.org/ip)
+          RESPONSE=$(curl -v -x http://127.0.0.1:3128 http://127.0.0.1:18081/ip 2>&1)
           echo "Response: ${RESPONSE}"
-          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL"; exit 1; }
+          echo "${RESPONSE}" | grep -q "test" || { echo "FAIL"; exit 1; }
           echo "--- HTTP via SOCKS5 auth OK ---"
-
-      - name: Test HTTPS through authenticated SOCKS5
-        run: |
-          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 https://httpbin.org/ip)
-          echo "Response: ${RESPONSE}"
-          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL"; exit 1; }
-          echo "--- HTTPS via SOCKS5 auth OK ---"
 
       - name: Show logs on failure
         if: failure()
@@ -321,6 +355,7 @@ jobs:
         if: always()
         run: |
           docker rm -f squid-auth socks5-auth 2>/dev/null || true
+          kill %1 2>/dev/null || true
 
   # ------------------------------------------------------------------
   # 5. Test: generate.php produces correct config

--- a/.github/workflows/squid-build-test.yml
+++ b/.github/workflows/squid-build-test.yml
@@ -1,0 +1,379 @@
+name: Squid SOCKS Patch Build & Test
+
+on:
+  push:
+    paths:
+      - 'squid_patch/**'
+      - 'setup/**'
+      - 'template/**'
+      - '.github/workflows/squid-build-test.yml'
+  pull_request:
+    paths:
+      - 'squid_patch/**'
+      - 'setup/**'
+      - 'template/**'
+      - '.github/workflows/squid-build-test.yml'
+  workflow_dispatch:
+
+env:
+  SQUID_IMAGE: squid-socks:6.10
+
+jobs:
+  # ------------------------------------------------------------------
+  # 1. Build the custom Squid image with SOCKS patch
+  # ------------------------------------------------------------------
+  build:
+    name: Build Squid 6.10 + SOCKS Patch
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Squid image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./squid_patch
+          file: ./squid_patch/Dockerfile
+          tags: ${{ env.SQUID_IMAGE }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify Squid binary
+        run: |
+          docker run --rm ${{ env.SQUID_IMAGE }} squid -v
+          echo "--- Squid binary OK ---"
+
+      - name: Save image for test jobs
+        run: docker save ${{ env.SQUID_IMAGE }} -o /tmp/squid-image.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: squid-image
+          path: /tmp/squid-image.tar
+          retention-days: 1
+
+  # ------------------------------------------------------------------
+  # 2. Test: Squid config parsing (socks4/socks5 options)
+  # ------------------------------------------------------------------
+  test-config:
+    name: Test Squid Config Parsing
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: squid-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load -i /tmp/squid-image.tar
+
+      - name: Test SOCKS5 cache_peer config parsing
+        run: |
+          cat > /tmp/squid-socks5.conf <<'CONF'
+          http_port 3128
+          acl all src 0.0.0.0/0
+          http_access allow all
+          never_direct allow all
+          cache_peer 127.0.0.1 parent 1080 0 no-query no-digest round-robin proxy-only originserver name=test_socks5 socks5 socks-user=testuser socks-pass=testpass
+          CONF
+
+          docker run --rm \
+            -v /tmp/squid-socks5.conf:/etc/squid/conf.d/squid.conf:ro \
+            ${{ env.SQUID_IMAGE }} \
+            squid -k parse -f /etc/squid/conf.d/squid.conf 2>&1 | tee /tmp/parse-output.txt
+
+          echo "--- SOCKS5 config parse OK ---"
+
+      - name: Test SOCKS4 cache_peer config parsing
+        run: |
+          cat > /tmp/squid-socks4.conf <<'CONF'
+          http_port 3128
+          acl all src 0.0.0.0/0
+          http_access allow all
+          never_direct allow all
+          cache_peer 127.0.0.1 parent 1080 0 no-query no-digest round-robin proxy-only originserver name=test_socks4 socks4
+          CONF
+
+          docker run --rm \
+            -v /tmp/squid-socks4.conf:/etc/squid/conf.d/squid.conf:ro \
+            ${{ env.SQUID_IMAGE }} \
+            squid -k parse -f /etc/squid/conf.d/squid.conf 2>&1 | tee /tmp/parse-output.txt
+
+          echo "--- SOCKS4 config parse OK ---"
+
+      - name: Test multiple SOCKS peers config
+        run: |
+          cat > /tmp/squid-multi.conf <<'CONF'
+          http_port 3128
+          acl all src 0.0.0.0/0
+          http_access allow all
+          never_direct allow all
+          cache_peer 10.0.0.1 parent 1080 0 no-query no-digest round-robin proxy-only originserver name=socks1 socks5 socks-user=user1 socks-pass=pass1
+          cache_peer 10.0.0.2 parent 1080 0 no-query no-digest round-robin proxy-only originserver name=socks2 socks5 socks-user=user2 socks-pass=pass2
+          cache_peer 10.0.0.3 parent 1081 0 no-query no-digest round-robin proxy-only originserver name=socks3 socks4
+          CONF
+
+          docker run --rm \
+            -v /tmp/squid-multi.conf:/etc/squid/conf.d/squid.conf:ro \
+            ${{ env.SQUID_IMAGE }} \
+            squid -k parse -f /etc/squid/conf.d/squid.conf 2>&1
+
+          echo "--- Multiple SOCKS peers config OK ---"
+
+  # ------------------------------------------------------------------
+  # 3. Test: SOCKS5 proxy end-to-end via Squid
+  # ------------------------------------------------------------------
+  test-socks5-e2e:
+    name: Test SOCKS5 End-to-End
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: squid-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load -i /tmp/squid-image.tar
+
+      - name: Start SOCKS5 test server (microsocks)
+        run: |
+          docker run -d --name socks5-server --network host \
+            ghcr.io/rofl0r/microsocks:latest -p 11080
+          sleep 2
+          docker logs socks5-server
+
+      - name: Create Squid config for SOCKS5 peer
+        run: |
+          mkdir -p /tmp/squid-conf
+          cat > /tmp/squid-conf/squid.conf <<'CONF'
+          http_port 3128
+          acl all src 0.0.0.0/0
+          http_access allow all
+          never_direct allow all
+          server_persistent_connections off
+          client_persistent_connections off
+          cache_peer 127.0.0.1 parent 11080 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_test socks5
+          visible_hostname test
+          access_log stdio:/proc/self/fd/1 combined
+          CONF
+
+          cat > /tmp/squid-conf/allowed_ip.txt <<'ALLOW'
+          0.0.0.0/0
+          ALLOW
+
+      - name: Start Squid with SOCKS5 peer
+        run: |
+          docker run -d --name squid-test --network host \
+            -v /tmp/squid-conf:/etc/squid/conf.d:ro \
+            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
+            ${{ env.SQUID_IMAGE }}
+          echo "Waiting for Squid to start..."
+          for i in $(seq 1 15); do
+            if curl -sf -x http://127.0.0.1:3128 -o /dev/null http://httpbin.org/ip 2>/dev/null; then
+              echo "Squid is ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Test HTTP request through SOCKS5 peer
+        run: |
+          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 http://httpbin.org/ip)
+          echo "Response: ${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL: unexpected response"; exit 1; }
+          echo "--- HTTP via SOCKS5 OK ---"
+
+      - name: Test HTTPS request through SOCKS5 peer
+        run: |
+          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 https://httpbin.org/ip)
+          echo "Response: ${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL: unexpected response"; exit 1; }
+          echo "--- HTTPS via SOCKS5 OK ---"
+
+      - name: Show Squid logs on failure
+        if: failure()
+        run: |
+          echo "=== Squid logs ==="
+          docker logs squid-test 2>&1 || true
+          echo "=== SOCKS5 server logs ==="
+          docker logs socks5-server 2>&1 || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f squid-test socks5-server 2>/dev/null || true
+
+  # ------------------------------------------------------------------
+  # 4. Test: SOCKS5 with authentication
+  # ------------------------------------------------------------------
+  test-socks5-auth:
+    name: Test SOCKS5 with Auth
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: squid-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load -i /tmp/squid-image.tar
+
+      - name: Start SOCKS5 server with auth (microsocks)
+        run: |
+          docker run -d --name socks5-auth --network host \
+            ghcr.io/rofl0r/microsocks:latest -u testuser -P testpass -p 11081
+          sleep 2
+
+      - name: Create Squid config with SOCKS5 auth
+        run: |
+          mkdir -p /tmp/squid-conf-auth
+          cat > /tmp/squid-conf-auth/squid.conf <<'CONF'
+          http_port 3128
+          acl all src 0.0.0.0/0
+          http_access allow all
+          never_direct allow all
+          server_persistent_connections off
+          client_persistent_connections off
+          cache_peer 127.0.0.1 parent 11081 0 no-query no-digest connect-fail-limit=2 connect-timeout=8 round-robin proxy-only originserver name=socks_auth socks5 socks-user=testuser socks-pass=testpass
+          visible_hostname test
+          access_log stdio:/proc/self/fd/1 combined
+          CONF
+
+          cat > /tmp/squid-conf-auth/allowed_ip.txt <<'ALLOW'
+          0.0.0.0/0
+          ALLOW
+
+      - name: Start Squid with SOCKS5 auth peer
+        run: |
+          docker run -d --name squid-auth --network host \
+            -v /tmp/squid-conf-auth:/etc/squid/conf.d:ro \
+            -e SQUID_CONFIG_FILE=/etc/squid/conf.d/squid.conf \
+            ${{ env.SQUID_IMAGE }}
+          for i in $(seq 1 15); do
+            if curl -sf -x http://127.0.0.1:3128 -o /dev/null http://httpbin.org/ip 2>/dev/null; then
+              echo "Squid ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Test HTTP through authenticated SOCKS5
+        run: |
+          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 http://httpbin.org/ip)
+          echo "Response: ${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL"; exit 1; }
+          echo "--- HTTP via SOCKS5 auth OK ---"
+
+      - name: Test HTTPS through authenticated SOCKS5
+        run: |
+          RESPONSE=$(curl -sf -x http://127.0.0.1:3128 https://httpbin.org/ip)
+          echo "Response: ${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "origin" || { echo "FAIL"; exit 1; }
+          echo "--- HTTPS via SOCKS5 auth OK ---"
+
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          echo "=== Squid logs ==="
+          docker logs squid-auth 2>&1 || true
+          echo "=== SOCKS5 auth server logs ==="
+          docker logs socks5-auth 2>&1 || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f squid-auth socks5-auth 2>/dev/null || true
+
+  # ------------------------------------------------------------------
+  # 5. Test: generate.php produces correct config
+  # ------------------------------------------------------------------
+  test-generate:
+    name: Test Config Generator
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PHP dependencies
+        run: |
+          docker run --rm -v "$(pwd)/setup:/app" -w /app composer:2 install --no-interaction --quiet
+
+      - name: Run generate.php with SOCKS proxy list
+        run: |
+          cat > proxyList.txt <<'LIST'
+          10.0.0.1:1080:socks5:user1:pass1
+          10.0.0.2:1080:socks5:user2:pass2
+          10.0.0.3:1081:socks4::
+          192.168.1.1:8080
+          10.0.0.4:3128:httpsquid:admin:secret
+          10.0.0.5:8080:http:user:pass
+          LIST
+
+          docker run --rm -v "$(pwd):/app" php:8.2-cli php /app/setup/generate.php
+
+      - name: Verify generated squid.conf has SOCKS peers
+        run: |
+          echo "=== Generated squid.conf ==="
+          cat config/squid.conf
+          echo ""
+
+          # Check socks5 peers use native SOCKS options
+          grep -q 'socks5' config/squid.conf || { echo "FAIL: socks5 option not found"; exit 1; }
+          grep -q 'socks-user=user1' config/squid.conf || { echo "FAIL: socks-user not found"; exit 1; }
+          grep -q 'socks-pass=pass1' config/squid.conf || { echo "FAIL: socks-pass not found"; exit 1; }
+          grep -q 'originserver' config/squid.conf || { echo "FAIL: originserver not found"; exit 1; }
+
+          # Check socks4 peer
+          grep -q 'socks4' config/squid.conf || { echo "FAIL: socks4 option not found"; exit 1; }
+
+          # Check open proxy (no socks, no gost)
+          grep -q 'name=public' config/squid.conf || { echo "FAIL: open proxy not found"; exit 1; }
+
+          # Check httpsquid peer
+          grep -q 'name=private' config/squid.conf || { echo "FAIL: httpsquid peer not found"; exit 1; }
+
+          echo "--- squid.conf generation OK ---"
+
+      - name: Verify generated docker-compose.yml
+        run: |
+          echo "=== Generated docker-compose.yml ==="
+          cat docker-compose.yml
+          echo ""
+
+          # Gost container should only exist for http type (not for socks4/socks5)
+          # We have 1 http proxy -> 1 gost container
+          GOST_COUNT=$(grep -c 'ginuerzh/gost' docker-compose.yml || true)
+          echo "Gost containers: ${GOST_COUNT}"
+          [ "${GOST_COUNT}" -eq 1 ] || { echo "FAIL: expected 1 gost container, got ${GOST_COUNT}"; exit 1; }
+
+          echo "--- docker-compose.yml generation OK ---"
+
+      - name: Verify no Gost for SOCKS proxies
+        run: |
+          # socks5/socks4 should NOT create gost containers
+          # Only 'http' type should use gost
+          if grep -q 'dockergost_1\|dockergost_2\|dockergost_3' docker-compose.yml; then
+            echo "FAIL: SOCKS proxies should not create Gost containers"
+            exit 1
+          fi
+          echo "--- No Gost for SOCKS proxies OK ---"

--- a/setup/generate.php
+++ b/setup/generate.php
@@ -19,12 +19,46 @@ $squid_default = 'cache_peer %s parent %d 0 no-digest no-netdb-exchange connect-
 // the connection is direct to the target (not an HTTP proxy).
 $squid_socks = 'cache_peer %s parent %d 0 no-digest no-netdb-exchange connect-fail-limit=2 connect-timeout=8 round-robin no-query allow-miss proxy-only originserver name=%s %s';
 
+// Reject any byte that could break squid.conf tokenization or inject
+// a new directive (whitespace, control chars, quotes, backslash, '#').
+// Applied to host/user/pass to prevent config injection from a tainted
+// proxyList.txt (e.g. one fetched from a remote URL).
+$reject_unsafe = '/[\s"#\\\\\x00-\x1F\x7F]/';
+
 while ($line = fgets($proxies)){
     $line = trim($line);
+    if ($line === '' || $line[0] === '#') {
+        continue;
+    }
     $proxyInfo = array_combine($keys, array_pad((explode(":", $line, 5)), 5, ''));
     $squid_conf = [];
     $cred = '';
     if(!$proxyInfo['host'] && !$proxyInfo['port']){
+        continue;
+    }
+
+    // Validate host: hostname or IPv4/IPv6 literal. No shell/conf metachars.
+    if (preg_match($reject_unsafe, $proxyInfo['host']) ||
+        !preg_match('/^[A-Za-z0-9.:\[\]_-]+$/', $proxyInfo['host'])) {
+        fwrite(STDERR, "Skipping proxy with invalid host: " . $proxyInfo['host'] . PHP_EOL);
+        continue;
+    }
+    // Validate port: 1-65535.
+    if (!ctype_digit((string)$proxyInfo['port']) ||
+        (int)$proxyInfo['port'] < 1 || (int)$proxyInfo['port'] > 65535) {
+        fwrite(STDERR, "Skipping proxy with invalid port: " . $proxyInfo['port'] . PHP_EOL);
+        continue;
+    }
+    // Validate credentials: no whitespace/control chars/quotes/backslash/#.
+    // (SOCKS5 RFC1929 allows up to 255 bytes of arbitrary octets, but we
+    //  conservatively reject bytes that would break squid.conf.)
+    if (($proxyInfo['user'] !== '' && preg_match($reject_unsafe, $proxyInfo['user'])) ||
+        ($proxyInfo['pass'] !== '' && preg_match($reject_unsafe, $proxyInfo['pass']))) {
+        fwrite(STDERR, "Skipping proxy with unsafe characters in credentials: " . $proxyInfo['host'] . PHP_EOL);
+        continue;
+    }
+    if (strlen($proxyInfo['user']) > 255 || strlen($proxyInfo['pass']) > 255) {
+        fwrite(STDERR, "Skipping proxy with credentials exceeding 255 bytes: " . $proxyInfo['host'] . PHP_EOL);
         continue;
     }
 

--- a/setup/generate.php
+++ b/setup/generate.php
@@ -15,6 +15,10 @@ $gluetun_http_port = 8888;
 $keys = ['host', 'port', 'scheme', 'user', 'pass'];
 $squid_default = 'cache_peer %s parent %d 0 no-digest no-netdb-exchange connect-fail-limit=2 connect-timeout=8 round-robin no-query allow-miss proxy-only name=%s';
 
+// SOCKS cache_peer template: uses originserver because after SOCKS tunnel
+// the connection is direct to the target (not an HTTP proxy).
+$squid_socks = 'cache_peer %s parent %d 0 no-digest no-netdb-exchange connect-fail-limit=2 connect-timeout=8 round-robin no-query allow-miss proxy-only originserver name=%s %s';
+
 while ($line = fgets($proxies)){
     $line = trim($line);
     $proxyInfo = array_combine($keys, array_pad((explode(":", $line, 5)), 5, ''));
@@ -36,8 +40,25 @@ while ($line = fgets($proxies)){
             //Username:Password Auth
             $squid_conf[] = vsprintf('login=%s:%s', array_map('urlencode', [$proxyInfo['user'], $proxyInfo['pass']]));
         }
-    }else{
-        //other proxy type ex:socks
+    }
+    elseif(in_array($proxyInfo['scheme'], ['socks4', 'socks5'], true)){
+        // Native SOCKS support via Squid cache_peer patch (no Gost needed)
+        $socksOpt = $proxyInfo['scheme'];  // "socks4" or "socks5"
+        if ($proxyInfo['user'] && $proxyInfo['pass']) {
+            $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
+                urlencode($proxyInfo['user']),
+                urlencode($proxyInfo['pass'])
+            );
+        }
+        $squid_conf[] = sprintf($squid_socks,
+            $proxyInfo['host'],
+            $proxyInfo['port'],
+            'socks'.$i,
+            $socksOpt
+        );
+    }
+    else{
+        // Other proxy types (http, https, etc.) – use Gost as HTTP proxy bridge
         if ($proxyInfo['user'] && $proxyInfo['pass']) {
             $cred = vsprintf('%s:%s@', array_map('urlencode', [$proxyInfo['user'], $proxyInfo['pass']]));
         }

--- a/setup/generate.php
+++ b/setup/generate.php
@@ -45,9 +45,10 @@ while ($line = fgets($proxies)){
         // Native SOCKS support via Squid cache_peer patch (no Gost needed)
         $socksOpt = $proxyInfo['scheme'];  // "socks4" or "socks5"
         if ($proxyInfo['user'] && $proxyInfo['pass']) {
+            // SOCKS5 RFC1929 uses raw username/password; do not URL-encode.
             $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
-                urlencode($proxyInfo['user']),
-                urlencode($proxyInfo['pass'])
+                $proxyInfo['user'],
+                $proxyInfo['pass']
             );
         }
         $squid_conf[] = sprintf($squid_socks,

--- a/setup/generate.php
+++ b/setup/generate.php
@@ -81,12 +81,17 @@ while ($line = fgets($proxies)){
     elseif(in_array($proxyInfo['scheme'], ['socks4', 'socks5'], true)){
         // Native SOCKS support via Squid cache_peer patch (no Gost needed)
         $socksOpt = $proxyInfo['scheme'];  // "socks4" or "socks5"
-        if ($proxyInfo['user'] && $proxyInfo['pass']) {
+        // socks-user/socks-pass are only valid with socks5 (RFC1929).
+        // The Squid patch rejects them on socks4, so emitting them there
+        // would break config parsing.  Skip and warn for socks4 entries.
+        if ($proxyInfo['scheme'] === 'socks5' && $proxyInfo['user'] && $proxyInfo['pass']) {
             // SOCKS5 RFC1929 uses raw username/password; do not URL-encode.
             $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
                 $proxyInfo['user'],
                 $proxyInfo['pass']
             );
+        } elseif ($proxyInfo['scheme'] === 'socks4' && ($proxyInfo['user'] || $proxyInfo['pass'])) {
+            fwrite(STDERR, "Note: SOCKS4 credentials ignored (use socks5 for auth): " . $proxyInfo['host'] . PHP_EOL);
         }
         $squid_conf[] = sprintf($squid_socks,
             $proxyInfo['host'],

--- a/setup/generate.php
+++ b/setup/generate.php
@@ -37,16 +37,19 @@ while ($line = fgets($proxies)){
         continue;
     }
 
-    // Validate host: hostname or IPv4/IPv6 literal. No shell/conf metachars.
+    // Validate host: hostname or IPv4 literal. No shell/conf metachars.
+    // IPv6 literals are not supported: the naive explode(":") parser above
+    // cannot split "[::1]:8080:..." correctly, so ':' / '[' / ']' are rejected
+    // to avoid giving the impression that IPv6 is accepted.
     if (preg_match($reject_unsafe, $proxyInfo['host']) ||
-        !preg_match('/^[A-Za-z0-9.:\[\]_-]+$/', $proxyInfo['host'])) {
-        fwrite(STDERR, "Skipping proxy with invalid host: " . $proxyInfo['host'] . PHP_EOL);
+        !preg_match('/^[A-Za-z0-9._-]+$/', $proxyInfo['host'])) {
+        fwrite(STDERR, "Skipping proxy with invalid host: " . rawurlencode($proxyInfo['host']) . PHP_EOL);
         continue;
     }
     // Validate port: 1-65535.
     if (!ctype_digit((string)$proxyInfo['port']) ||
         (int)$proxyInfo['port'] < 1 || (int)$proxyInfo['port'] > 65535) {
-        fwrite(STDERR, "Skipping proxy with invalid port: " . $proxyInfo['port'] . PHP_EOL);
+        fwrite(STDERR, "Skipping proxy with invalid port: " . rawurlencode((string)$proxyInfo['port']) . PHP_EOL);
         continue;
     }
     // Validate credentials: no whitespace/control chars/quotes/backslash/#.

--- a/setup/generate.php
+++ b/setup/generate.php
@@ -84,13 +84,24 @@ while ($line = fgets($proxies)){
         // socks-user/socks-pass are only valid with socks5 (RFC1929).
         // The Squid patch rejects them on socks4, so emitting them there
         // would break config parsing.  Skip and warn for socks4 entries.
-        if ($proxyInfo['scheme'] === 'socks5' && $proxyInfo['user'] && $proxyInfo['pass']) {
-            // SOCKS5 RFC1929 uses raw username/password; do not URL-encode.
-            $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
-                $proxyInfo['user'],
-                $proxyInfo['pass']
-            );
-        } elseif ($proxyInfo['scheme'] === 'socks4' && ($proxyInfo['user'] || $proxyInfo['pass'])) {
+        // Use !== '' rather than truthy checks so values like '0' are
+        // treated as valid credentials, and so a half-filled pair does
+        // not silently fall back to no-auth.
+        $hasUser = ($proxyInfo['user'] !== '');
+        $hasPass = ($proxyInfo['pass'] !== '');
+        if ($proxyInfo['scheme'] === 'socks5') {
+            if ($hasUser xor $hasPass) {
+                fwrite(STDERR, "Skipping SOCKS5 proxy with incomplete credentials: " . $proxyInfo['host'] . PHP_EOL);
+                continue;
+            }
+            if ($hasUser && $hasPass) {
+                // SOCKS5 RFC1929 uses raw username/password; do not URL-encode.
+                $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
+                    $proxyInfo['user'],
+                    $proxyInfo['pass']
+                );
+            }
+        } elseif ($proxyInfo['scheme'] === 'socks4' && ($hasUser || $hasPass)) {
             fwrite(STDERR, "Note: SOCKS4 credentials ignored (use socks5 for auth): " . $proxyInfo['host'] . PHP_EOL);
         }
         $squid_conf[] = sprintf($squid_socks,

--- a/squid_patch/.dockerignore
+++ b/squid_patch/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+*.md

--- a/squid_patch/Dockerfile
+++ b/squid_patch/Dockerfile
@@ -64,7 +64,8 @@ RUN cd "squid-${SQUID_VERSION}" \
         --with-default-user=squid \
         --disable-strict-error-checking \
     && make -j"$(nproc)" \
-    && make install DESTDIR=/install
+    && make install DESTDIR=/install \
+    && rm -rf /install/var/run
 
 # ---------- stage 2: runtime ----------------------------------------------
 FROM debian:bookworm-slim

--- a/squid_patch/Dockerfile
+++ b/squid_patch/Dockerfile
@@ -95,4 +95,6 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 3128
 
+# Starts as root so docker-entrypoint.sh can run squid -z (cache init) and chown;
+# privileges are dropped to squid user via gosu before starting the daemon.
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/squid_patch/Dockerfile
+++ b/squid_patch/Dockerfile
@@ -30,13 +30,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-# Download and extract Squid source (pinned version + integrity check)
+# Download and extract Squid source (pinned version + integrity check).
+# Fetch from several mirrors with retries: the primary www.squid-cache.org
+# host has intermittent outages.  Integrity is guaranteed by the SHA256 check
+# regardless of which mirror served the bytes, so mirror order is safe.
 ARG SQUID_TAR_SHA256=0b07b187e723f04770dd25beb89aec12030a158696aa8892d87c8b26853408a7
-RUN wget -q "https://www.squid-cache.org/Versions/v6/squid-${SQUID_VERSION}.tar.xz" \
-        -O squid.tar.xz \
-    && echo "${SQUID_TAR_SHA256}  squid.tar.xz" | sha256sum -c - \
-    && tar xf squid.tar.xz \
-    && rm squid.tar.xz
+RUN set -eux; \
+    SQUID_TAG="SQUID_$(echo "${SQUID_VERSION}" | tr . _)"; \
+    for url in \
+        "https://github.com/squid-cache/squid/releases/download/${SQUID_TAG}/squid-${SQUID_VERSION}.tar.xz" \
+        "https://www.squid-cache.org/Versions/v6/squid-${SQUID_VERSION}.tar.xz" \
+        "http://www.squid-cache.org/Versions/v6/squid-${SQUID_VERSION}.tar.xz" \
+    ; do \
+        echo "Fetching Squid source: ${url}"; \
+        if wget -q --tries=3 --timeout=30 -O squid.tar.xz "${url}"; then \
+            echo "Downloaded from ${url}"; \
+            break; \
+        fi; \
+        rm -f squid.tar.xz; \
+    done; \
+    echo "${SQUID_TAR_SHA256}  squid.tar.xz" | sha256sum -c -; \
+    tar xf squid.tar.xz; \
+    rm squid.tar.xz
 
 # Copy patch sources and apply
 COPY src/    /patches/src/

--- a/squid_patch/Dockerfile
+++ b/squid_patch/Dockerfile
@@ -67,6 +67,7 @@ RUN cd "squid-${SQUID_VERSION}" \
 # ---------- stage 2: runtime ----------------------------------------------
 FROM debian:bookworm-slim
 
+ARG SQUID_VERSION=6.10
 LABEL maintainer="docker-rotating-proxy"
 LABEL description="Squid ${SQUID_VERSION} with SOCKS4/SOCKS5 cache_peer support"
 

--- a/squid_patch/Dockerfile
+++ b/squid_patch/Dockerfile
@@ -1,0 +1,93 @@
+# ==========================================================================
+# Custom Squid build with SOCKS4/SOCKS5 cache_peer support
+#
+# Pinned version: Squid 6.10
+# Reference: https://wiki.squid-cache.org/Features/Socks
+# ==========================================================================
+
+ARG SQUID_VERSION=6.10
+
+# ---------- stage 1: build ------------------------------------------------
+FROM debian:bookworm-slim AS builder
+
+ARG SQUID_VERSION
+ENV SQUID_VERSION=${SQUID_VERSION}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        wget \
+        ca-certificates \
+        pkg-config \
+        autoconf \
+        automake \
+        libtool \
+        libssl-dev \
+        libcap-dev \
+        libexpat1-dev \
+        libltdl-dev \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Download and extract Squid source (pinned version)
+RUN wget -q "http://www.squid-cache.org/Versions/v6/squid-${SQUID_VERSION}.tar.xz" \
+        -O squid.tar.xz \
+    && tar xf squid.tar.xz \
+    && rm squid.tar.xz
+
+# Copy patch sources and apply
+COPY src/    /patches/src/
+COPY patch_apply.sh /patches/
+
+RUN chmod +x /patches/patch_apply.sh \
+    && bash /patches/patch_apply.sh /patches/src "/build/squid-${SQUID_VERSION}"
+
+# Configure and build
+RUN cd "squid-${SQUID_VERSION}" \
+    && ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc/squid \
+        --localstatedir=/var \
+        --libexecdir=/usr/lib/squid \
+        --datadir=/usr/share/squid \
+        --with-openssl \
+        --enable-ssl-crtd \
+        --enable-delay-pools \
+        --enable-removal-policies="lru,heap" \
+        --enable-cache-digests \
+        --enable-follow-x-forwarded-for \
+        --disable-arch-native \
+        --with-large-files \
+        --with-default-user=squid \
+        --disable-strict-error-checking \
+    && make -j"$(nproc)" \
+    && make install DESTDIR=/install
+
+# ---------- stage 2: runtime ----------------------------------------------
+FROM debian:bookworm-slim
+
+LABEL maintainer="docker-rotating-proxy"
+LABEL description="Squid ${SQUID_VERSION} with SOCKS4/SOCKS5 cache_peer support"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libssl3 \
+        libcap2 \
+        libexpat1 \
+        libltdl7 \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install/ /
+
+RUN useradd -r -M -d /var/cache/squid -s /sbin/nologin squid \
+    && mkdir -p /var/cache/squid /var/log/squid /var/run/squid /etc/squid/conf.d \
+    && chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid /etc/squid/conf.d
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 3128
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/squid_patch/Dockerfile
+++ b/squid_patch/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /build
 
 # Download and extract Squid source (pinned version)
-RUN wget -q "http://www.squid-cache.org/Versions/v6/squid-${SQUID_VERSION}.tar.xz" \
+RUN wget -q "https://www.squid-cache.org/Versions/v6/squid-${SQUID_VERSION}.tar.xz" \
         -O squid.tar.xz \
     && tar xf squid.tar.xz \
     && rm squid.tar.xz
@@ -78,6 +78,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libltdl7 \
         ca-certificates \
         curl \
+        gosu \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install/ /

--- a/squid_patch/Dockerfile
+++ b/squid_patch/Dockerfile
@@ -30,9 +30,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-# Download and extract Squid source (pinned version)
+# Download and extract Squid source (pinned version + integrity check)
+ARG SQUID_TAR_SHA256=0b07b187e723f04770dd25beb89aec12030a158696aa8892d87c8b26853408a7
 RUN wget -q "https://www.squid-cache.org/Versions/v6/squid-${SQUID_VERSION}.tar.xz" \
         -O squid.tar.xz \
+    && echo "${SQUID_TAR_SHA256}  squid.tar.xz" | sha256sum -c - \
     && tar xf squid.tar.xz \
     && rm squid.tar.xz
 

--- a/squid_patch/docker-entrypoint.sh
+++ b/squid_patch/docker-entrypoint.sh
@@ -15,5 +15,17 @@ chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>/dev/null 
 # Remove stale PID file left by squid -z (created as root)
 rm -f /var/run/squid.pid /var/run/squid/squid.pid 2>/dev/null || true
 
-echo "Starting Squid with config: ${SQUID_CONFIG_FILE}"
-exec gosu squid squid -N -f "${SQUID_CONFIG_FILE}" "$@"
+# Support both direct squid invocation and arbitrary commands.
+# If the first argument is "squid", drop it to avoid "squid squid ..." duplication.
+if [ "$#" -gt 0 ] && [ "$1" = "squid" ]; then
+    shift
+fi
+
+# If there are no arguments, or the first arg starts with "-", treat them as squid options.
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    echo "Starting Squid with config: ${SQUID_CONFIG_FILE}"
+    exec gosu squid squid -N -f "${SQUID_CONFIG_FILE}" "$@"
+fi
+
+# Otherwise, run the provided command as-is (e.g., a shell or another tool).
+exec "$@"

--- a/squid_patch/docker-entrypoint.sh
+++ b/squid_patch/docker-entrypoint.sh
@@ -12,5 +12,8 @@ fi
 # Ensure proper ownership
 chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>/dev/null || true
 
+# Remove stale PID file left by squid -z (created as root)
+rm -f /var/run/squid.pid /var/run/squid/squid.pid 2>/dev/null || true
+
 echo "Starting Squid with config: ${SQUID_CONFIG_FILE}"
 exec gosu squid squid -N -f "${SQUID_CONFIG_FILE}" "$@"

--- a/squid_patch/docker-entrypoint.sh
+++ b/squid_patch/docker-entrypoint.sh
@@ -6,7 +6,7 @@ SQUID_CONFIG_FILE="${SQUID_CONFIG_FILE:-/etc/squid/squid.conf}"
 # Initialize cache directory if needed
 if [ ! -d /var/cache/squid/00 ]; then
     echo "Initializing Squid cache..."
-    squid -z -N -f "${SQUID_CONFIG_FILE}" 2>/dev/null || true
+    squid -z -N -f "${SQUID_CONFIG_FILE}" 2>&1 || echo "Warning: squid -z failed (may be OK if cache is unused)"
 fi
 
 # Ensure proper ownership

--- a/squid_patch/docker-entrypoint.sh
+++ b/squid_patch/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+SQUID_CONFIG_FILE="${SQUID_CONFIG_FILE:-/etc/squid/squid.conf}"
+
+# Initialize cache directory if needed
+if [ ! -d /var/cache/squid/00 ]; then
+    echo "Initializing Squid cache..."
+    squid -z -N -f "${SQUID_CONFIG_FILE}" 2>/dev/null || true
+fi
+
+# Ensure proper ownership
+chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>/dev/null || true
+
+echo "Starting Squid with config: ${SQUID_CONFIG_FILE}"
+exec squid -N -f "${SQUID_CONFIG_FILE}" "$@"

--- a/squid_patch/docker-entrypoint.sh
+++ b/squid_patch/docker-entrypoint.sh
@@ -13,4 +13,4 @@ fi
 chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid 2>/dev/null || true
 
 echo "Starting Squid with config: ${SQUID_CONFIG_FILE}"
-exec squid -N -f "${SQUID_CONFIG_FILE}" "$@"
+exec gosu squid squid -N -f "${SQUID_CONFIG_FILE}" "$@"

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -4,10 +4,9 @@
 #
 # Usage: patch_apply.sh <patch_src_dir> <squid_src_dir>
 #
-# This script modifies the Squid source tree to add SOCKS4/SOCKS5
-# support for cache_peer directives.  It uses pattern-based sed
-# modifications so that it is tolerant of minor whitespace changes
-# across point releases of the same major version.
+# Modifies the Squid 6.x source tree to add SOCKS4/SOCKS5 support for
+# cache_peer directives.  Uses pattern-based modifications (sed + Python)
+# so that the script is tolerant of minor changes across 6.x point releases.
 #
 set -euo pipefail
 
@@ -27,39 +26,25 @@ CACHE_PEER_H="${SQUID_SRC}/src/CachePeer.h"
 echo "==> Patching ${CACHE_PEER_H}"
 [ -f "${CACHE_PEER_H}" ] || die "CachePeer.h not found"
 
-# Verify the file contains the struct we expect
 grep -q 'class CachePeer' "${CACHE_PEER_H}" || die "CachePeer class not found"
 
-# Add include for SocksPeerConnector.h and string after existing includes
-if ! grep -q 'SocksPeerConnector.h' "${CACHE_PEER_H}"; then
-    sed -i '/#ifndef SQUID_SRC_CACHEPEER_H/,/#define SQUID_SRC_CACHEPEER_H/{
-        /#define SQUID_SRC_CACHEPEER_H/a\
-\
-#include "SocksPeerConnector.h"\
-#include <string>
-    }' "${CACHE_PEER_H}"
-fi
-
-# Add SOCKS fields to CachePeer class – insert before the closing brace + semicolon
-# We look for a known member and add after it, or add before the end of the class
+# Do NOT include SocksPeerConnector.h here – it pulls in POSIX headers
+# that must come after squid.h.  Use plain int/char* for the fields.
 if ! grep -q 'socks_type' "${CACHE_PEER_H}"; then
-    # Find "} options;" line (the options struct closing) and add SOCKS fields after it
     if grep -q '} options;' "${CACHE_PEER_H}" 2>/dev/null; then
         sed -i '/} options;/a\
 \
-    /* SOCKS proxy support for cache_peer */\
-    SocksPeerType socks_type = SOCKS_NONE;\
-    std::string socks_user;\
-    std::string socks_pass;' "${CACHE_PEER_H}"
+    /* SOCKS proxy support for cache_peer (0=none, 4=SOCKS4, 5=SOCKS5) */\
+    int socks_type = 0;\
+    char *socks_user = nullptr;\
+    char *socks_pass = nullptr;' "${CACHE_PEER_H}"
     else
-        # Fallback: add before the last closing brace of the class
-        # Find "CBDATA_CLASS" or last "};" and insert before it
         sed -i '/^};/i\
 \
-    /* SOCKS proxy support for cache_peer */\
-    SocksPeerType socks_type = SOCKS_NONE;\
-    std::string socks_user;\
-    std::string socks_pass;\
+    /* SOCKS proxy support for cache_peer (0=none, 4=SOCKS4, 5=SOCKS5) */\
+    int socks_type = 0;\
+    char *socks_user = nullptr;\
+    char *socks_pass = nullptr;\
 ' "${CACHE_PEER_H}"
     fi
 fi
@@ -74,15 +59,6 @@ echo "==> Patching ${CACHE_CF}"
 [ -f "${CACHE_CF}" ] || die "cache_cf.cc not found"
 
 if ! grep -q 'socks_type' "${CACHE_CF}"; then
-    # Find the peer option parsing block. In Squid 6.x, options are parsed
-    # in a loop that checks token values like "no-query", "proxy-only", etc.
-    # We add our SOCKS options alongside the existing option parsing.
-    #
-    # Strategy: find the pattern 'strcmp(token, "proxy-only")' or similar
-    # well-known option and add our parsing block after the closing brace
-    # of that if-block.
-
-    # Try to find a good anchor point
     ANCHOR=""
     for pattern in 'proxy-only' 'no-digest' 'no-query' 'round-robin' 'originserver'; do
         if grep -q "\"${pattern}\"" "${CACHE_CF}"; then
@@ -91,14 +67,9 @@ if ! grep -q 'socks_type' "${CACHE_CF}"; then
         fi
     done
 
-    if [ -z "${ANCHOR}" ]; then
-        die "Could not find peer option parsing anchor in cache_cf.cc"
-    fi
-
+    [ -n "${ANCHOR}" ] || die "Could not find peer option parsing anchor in cache_cf.cc"
     echo "    Using anchor: '${ANCHOR}'"
 
-    # Insert SOCKS option parsing after the first occurrence of the anchor option block
-    # We use a Python script for reliable multi-line insertion
     python3 - "${CACHE_CF}" "${ANCHOR}" << 'PYEOF'
 import sys, re
 
@@ -108,18 +79,21 @@ anchor = sys.argv[2]
 with open(filepath, 'r') as f:
     content = f.read()
 
+# Use xstrdup for string allocation (Squid's malloc wrapper)
 socks_code = '''
         } else if (!strcmp(token, "socks4")) {
-            p->socks_type = SOCKS_V4;
+            p->socks_type = 4;
         } else if (!strcmp(token, "socks5")) {
-            p->socks_type = SOCKS_V5;
+            p->socks_type = 5;
         } else if (!strncmp(token, "socks-user=", 11)) {
-            p->socks_user = token + 11;
+            safe_free(p->socks_user);
+            p->socks_user = xstrdup(token + 11);
         } else if (!strncmp(token, "socks-pass=", 11)) {
-            p->socks_pass = token + 11;
+            safe_free(p->socks_pass);
+            p->socks_pass = xstrdup(token + 11);
 '''
 
-# Find the anchor pattern in a strcmp context
+# Find the anchor in a strcmp context and insert after its closing brace
 pattern = re.compile(
     r'(else\s+if\s*\(!strcmp\(token,\s*"' + re.escape(anchor) + r'"\)\)\s*\{[^}]*\})',
     re.DOTALL
@@ -133,13 +107,12 @@ if match:
         f.write(content)
     print(f"    Inserted SOCKS parsing after '{anchor}' block")
 else:
-    # Fallback: search for simpler pattern
+    # Fallback: brace-counting approach
     simple = f'"{anchor}"'
     idx = content.find(simple)
     if idx < 0:
         print(f"ERROR: Could not find '{anchor}' in cache_cf.cc", file=sys.stderr)
         sys.exit(1)
-    # Find the closing brace of this if block
     brace_start = content.find('{', idx)
     if brace_start < 0:
         print("ERROR: Could not find opening brace", file=sys.stderr)
@@ -160,24 +133,19 @@ fi
 echo "    cache_cf.cc patched OK"
 
 # ---------------------------------------------------------------------------
-# 3. FwdState.cc  –  SOCKS negotiation after TCP connect (HTTP requests)
+# 3. FwdState.cc  –  SOCKS negotiation at the top of dispatch()
 # ---------------------------------------------------------------------------
 FWD_STATE="${SQUID_SRC}/src/FwdState.cc"
 echo "==> Patching ${FWD_STATE}"
 [ -f "${FWD_STATE}" ] || die "FwdState.cc not found"
 
-# Add include
+# Add include – after the first #include line (squid.h is always first)
 if ! grep -q 'SocksPeerConnector.h' "${FWD_STATE}"; then
-    sed -i '/#include "FwdState.h"/a\
-#include "SocksPeerConnector.h"' "${FWD_STATE}"
+    sed -i '0,/#include/{s/#include/#include "SocksPeerConnector.h"\n#include/}' "${FWD_STATE}"
+    # Verify it was inserted
+    grep -q 'SocksPeerConnector.h' "${FWD_STATE}" || die "Failed to add include to FwdState.cc"
 fi
 
-# Add SOCKS negotiation hook.
-# In Squid 6.x, after connection is established to a peer, the code
-# eventually calls dispatch(). We insert SOCKS negotiation before dispatch.
-#
-# We look for the dispatch() call that happens after peer connection
-# and add SOCKS negotiation before it.
 if ! grep -q 'socks_type' "${FWD_STATE}"; then
     python3 - "${FWD_STATE}" << 'PYEOF'
 import sys, re
@@ -187,88 +155,76 @@ filepath = sys.argv[1]
 with open(filepath, 'r') as f:
     content = f.read()
 
+# Squid 6.x API:
+#   serverConnection() returns Comm::ConnectionPointer const &
+#   ->getPeer() returns CachePeer*
+#   ->fd is int (public member of Comm::Connection)
+#   request->url.host() returns SBuf (use .c_str() for const char*)
+#   request->url.port() returns unsigned short
+#   retryOrBail() is a private method of FwdState
 socks_hook = r'''
-    /* SOCKS peer negotiation: after TCP connect, before dispatch */
-    if (serverConnection()->getPeer() &&
-        serverConnection()->getPeer()->socks_type != SOCKS_NONE) {
-        CachePeer *sp = serverConnection()->getPeer();
-        const char *targetHost = request->url.host();
-        const uint16_t targetPort = request->url.port();
-        debugs(17, 3, "SOCKS" << (int)sp->socks_type
-               << " negotiation with peer " << sp->host
-               << " for " << targetHost << ":" << targetPort);
-        if (!SocksPeerConnector::negotiate(
-                serverConnection()->fd,
-                sp->socks_type,
-                std::string(targetHost),
-                targetPort,
-                sp->socks_user,
-                sp->socks_pass)) {
-            debugs(17, 2, "SOCKS negotiation FAILED for peer " << sp->host);
-            retryOrBail();
-            return;
+    /* SOCKS peer negotiation: after TCP connect, before HTTP dispatch */
+    if (const auto sp = serverConnection()->getPeer()) {
+        if (sp->socks_type) {
+            const auto targetPort = static_cast<uint16_t>(request->url.port());
+            debugs(17, 3, "SOCKS" << sp->socks_type
+                   << " negotiation with peer " << sp->host
+                   << " for " << request->url.host() << ":" << targetPort);
+            if (!SocksPeerConnector::negotiate(
+                    serverConnection()->fd,
+                    static_cast<SocksPeerType>(sp->socks_type),
+                    std::string(request->url.host().c_str()),
+                    targetPort,
+                    sp->socks_user ? std::string(sp->socks_user) : std::string(),
+                    sp->socks_pass ? std::string(sp->socks_pass) : std::string())) {
+                debugs(17, 2, "SOCKS negotiation FAILED for peer " << sp->host);
+                retryOrBail();
+                return;
+            }
+            debugs(17, 3, "SOCKS negotiation OK for peer " << sp->host);
         }
-        debugs(17, 3, "SOCKS negotiation OK for peer " << sp->host);
     }
 
 '''
 
-# Strategy: find the dispatch() call in a connected-to-peer context
-# Look for "dispatch()" preceded by peer-related code
-# Multiple possible patterns across Squid versions
-
 inserted = False
 
-# Pattern 1: Look for "void FwdState::dispatch()" and insert at the top of the function
-match = re.search(r'(void\s+FwdState::dispatch\s*\(\s*\)\s*\{)', content)
-if match:
-    insert_pos = match.end()
-    content = content[:insert_pos] + socks_hook + content[insert_pos:]
-    inserted = True
-    print("    Inserted SOCKS hook at top of FwdState::dispatch()")
-
-if not inserted:
-    # Pattern 2: look for "FwdState::dispatch" with different formatting
-    match = re.search(r'(FwdState::dispatch\(\)\s*\n?\{)', content)
+# Pattern: void FwdState::dispatch()  {
+for pat in [
+    r'(void\s+FwdState::dispatch\s*\(\s*\)\s*\{)',
+    r'(FwdState::dispatch\s*\(\s*\)\s*\n?\s*\{)',
+]:
+    match = re.search(pat, content)
     if match:
         insert_pos = match.end()
         content = content[:insert_pos] + socks_hook + content[insert_pos:]
         inserted = True
-        print("    Inserted SOCKS hook (pattern 2)")
+        print("    Inserted SOCKS hook at top of FwdState::dispatch()")
+        break
 
 if not inserted:
     print("ERROR: Could not find dispatch() insertion point in FwdState.cc", file=sys.stderr)
     print("       SOCKS support for HTTP requests will not work", file=sys.stderr)
     sys.exit(1)
-else:
-    with open(filepath, 'w') as f:
-        f.write(content)
 
+with open(filepath, 'w') as f:
+    f.write(content)
 PYEOF
 fi
 
 echo "    FwdState.cc patched OK"
 
 # ---------------------------------------------------------------------------
-# 4. tunnel.cc  –  SOCKS negotiation for CONNECT / HTTPS tunneling
+# 4. tunnel.cc  –  SOCKS negotiation in connectDone() for CONNECT/HTTPS
 # ---------------------------------------------------------------------------
 TUNNEL_CC="${SQUID_SRC}/src/tunnel.cc"
 echo "==> Patching ${TUNNEL_CC}"
 [ -f "${TUNNEL_CC}" ] || die "tunnel.cc not found"
 
+# Add include – after the first #include line
 if ! grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}"; then
-    # Add include near the top
-    sed -i '/#include "tunnel.h"\|#include "squid.h"\|#include "base\//{
-        /#include "squid.h"/a\
-#include "SocksPeerConnector.h"
-    }' "${TUNNEL_CC}"
-    # Fallback: if the above didn't match, try another pattern
-    if ! grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}"; then
-        sed -i '1,/^#include/{
-            /^#include/a\
-#include "SocksPeerConnector.h"
-        }' "${TUNNEL_CC}"
-    fi
+    sed -i '0,/#include/{s/#include/#include "SocksPeerConnector.h"\n#include/}' "${TUNNEL_CC}"
+    grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}" || die "Failed to add include to tunnel.cc"
 fi
 
 if ! grep -q 'socks_type' "${TUNNEL_CC}"; then
@@ -280,106 +236,74 @@ filepath = sys.argv[1]
 with open(filepath, 'r') as f:
     content = f.read()
 
-# In tunnel.cc, after connecting to a peer for CONNECT requests,
-# Squid sends "CONNECT host:port HTTP/1.1" to the peer.
-# For SOCKS peers, we need to do SOCKS negotiation instead.
-#
-# Look for the function that sends the CONNECT request to the peer.
-# Common function names: connectToPeer(), tunnelConnectDone(),
-# connectedToPeer(), writeServerConnect(), etc.
-
+# tunnel.cc API (Squid 6.x):
+#   TunnelStateData has: server.conn (Comm::ConnectionPointer), request (HttpRequestPointer)
+#   connectDone(const Comm::ConnectionPointer &conn, ...) - called after TCP connect
+#   conn->getPeer() returns CachePeer*
+#   conn->fd is int
+#   For originserver peers, connectDone goes to notePeerReadyToShovel() (shovels data)
+#   For non-origin peers, connectDone goes to connectToPeer() (sends HTTP CONNECT)
+#   SOCKS peers use originserver, so after SOCKS negotiation the tunnel is ready.
 socks_tunnel_hook = r'''
-    /* SOCKS peer: negotiate tunnel instead of HTTP CONNECT */
-    if (serverConnection()->getPeer() &&
-        serverConnection()->getPeer()->socks_type != SOCKS_NONE) {
-        CachePeer *sp = serverConnection()->getPeer();
-        const char *tHost = request->url.host();
-        const uint16_t tPort = request->url.port();
-        debugs(26, 3, "SOCKS" << (int)sp->socks_type
+    /* SOCKS peer: negotiate tunnel right after TCP connect */
+    if (conn->getPeer() && conn->getPeer()->socks_type) {
+        const auto sp = conn->getPeer();
+        const auto targetPort = static_cast<uint16_t>(request->url.port());
+        debugs(26, 3, "SOCKS" << sp->socks_type
                << " tunnel negotiation with peer " << sp->host
-               << " for " << tHost << ":" << tPort);
+               << " for " << request->url.host() << ":" << targetPort);
         if (!SocksPeerConnector::negotiate(
-                serverConnection()->fd,
-                sp->socks_type,
-                std::string(tHost),
-                tPort,
-                sp->socks_user,
-                sp->socks_pass)) {
+                conn->fd,
+                static_cast<SocksPeerType>(sp->socks_type),
+                std::string(request->url.host().c_str()),
+                targetPort,
+                sp->socks_user ? std::string(sp->socks_user) : std::string(),
+                sp->socks_pass ? std::string(sp->socks_pass) : std::string())) {
             debugs(26, 2, "SOCKS tunnel negotiation FAILED for " << sp->host);
-            ErrorState *err = new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al);
-            fail(err);
-            closeServerConnection("SOCKS negotiation failed");
+            conn->close();
             return;
         }
         debugs(26, 3, "SOCKS tunnel negotiation OK for " << sp->host);
-        /* After SOCKS negotiation, connection is a direct tunnel.
-         * Skip the HTTP CONNECT and go straight to relaying. */
-        connectExchangeCheckpoint();
-        return;
     }
 
 '''
 
 inserted = False
 
-# Look for the point where HTTP CONNECT is sent to peer
-# Pattern: a function that handles "connected to peer" and sends CONNECT
-for func_pattern in [
-    r'(void\s+TunnelStateData::connectToPeer\s*\([^)]*\)\s*\{)',
-    r'(TunnelStateData::connectedToPeer\s*\([^)]*\)\s*\{)',
+# Target: TunnelStateData::connectDone  or  tunnelConnectDone
+for pat in [
+    r'(void\s+TunnelStateData::connectDone\s*\([^)]*\)\s*\{)',
+    r'(TunnelStateData::connectDone\s*\([^)]*\)\s*\n?\s*\{)',
     r'(void\s+tunnelConnectDone\s*\([^)]*\)\s*\{)',
-    r'(TunnelStateData::sendConnectRequest\s*\([^)]*\)\s*\{)',
-    r'(TunnelStateData::noteConnection\s*\([^)]*\)\s*\{)',
+    # Fallback: connectToPeer
+    r'(void\s+TunnelStateData::connectToPeer\s*\([^)]*\)\s*\{)',
+    r'(TunnelStateData::connectToPeer\s*\([^)]*\)\s*\n?\s*\{)',
 ]:
-    match = re.search(func_pattern, content)
+    match = re.search(pat, content)
     if match:
         insert_pos = match.end()
         content = content[:insert_pos] + socks_tunnel_hook + content[insert_pos:]
         inserted = True
-        print(f"    Inserted SOCKS tunnel hook in {match.group(0)[:60]}...")
+        print(f"    Inserted SOCKS tunnel hook in {match.group(0).strip()[:70]}...")
         break
 
 if not inserted:
-    # Last resort: find any function with "peer" and "connect" in tunnel.cc
-    # and add the hook there
-    match = re.search(r'(void\s+\w+::\w*[Cc]onnect\w*\s*\([^)]*\)\s*\{)', content)
-    if match:
-        insert_pos = match.end()
-        content = content[:insert_pos] + socks_tunnel_hook + content[insert_pos:]
-        inserted = True
-        print(f"    Inserted SOCKS tunnel hook (fallback) in {match.group(0)[:60]}...")
-
-if inserted:
-    with open(filepath, 'w') as f:
-        f.write(content)
-else:
     print("ERROR: Could not patch tunnel.cc - HTTPS tunneling through SOCKS peers will not work", file=sys.stderr)
     sys.exit(1)
 
+with open(filepath, 'w') as f:
+    f.write(content)
 PYEOF
 fi
 
 echo "    tunnel.cc patched OK"
 
-# ---------------------------------------------------------------------------
-# 5. HttpStateData  –  use origin-server request format for SOCKS peers
-# ---------------------------------------------------------------------------
-# For SOCKS peers, after the SOCKS tunnel is established the connection
-# is effectively direct to the origin server. We must send requests in
-# origin format (GET /path) rather than proxy format (GET http://host/path).
-#
-# In Squid this is controlled by the CachePeer::options.originserver flag.
-# Rather than modifying HttpStateData, we set originserver = true for SOCKS
-# peers during configuration parsing (in cache_cf.cc).  This is already
-# handled because the Dockerfile squid.conf template uses the "originserver"
-# option explicitly.
-
 echo ""
 echo "==> All patches applied successfully"
 echo ""
 echo "Modified files:"
-echo "  - src/CachePeer.h       (added socks_type/user/pass fields)"
-echo "  - src/cache_cf.cc       (added socks4/socks5 option parsing)"
-echo "  - src/FwdState.cc       (added SOCKS negotiation before dispatch)"
-echo "  - src/tunnel.cc         (added SOCKS negotiation for CONNECT tunneling)"
-echo "  - src/SocksPeerConnector.h (new: SOCKS4/5 protocol implementation)"
+echo "  - src/CachePeer.h            (added socks_type/user/pass fields)"
+echo "  - src/cache_cf.cc            (added socks4/socks5 option parsing)"
+echo "  - src/FwdState.cc            (SOCKS negotiation in dispatch())"
+echo "  - src/tunnel.cc              (SOCKS negotiation in connectDone())"
+echo "  - src/SocksPeerConnector.h   (new: SOCKS4/5 protocol implementation)"

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -79,54 +79,57 @@ anchor = sys.argv[2]
 with open(filepath, 'r') as f:
     content = f.read()
 
-# Use xstrdup for string allocation (Squid's malloc wrapper)
-socks_code = '''
-        } else if (!strcmp(token, "socks4")) {
+# The code to insert. Starts with " else if" (no leading "}") and closes
+# the final branch with "}".  The insertion point is right after the "}"
+# that closes the anchor's if-block, so " else if" continues the chain.
+socks_code = ''' else if (!strcmp(token, "socks4")) {
             p->socks_type = 4;
+            if (!p->options.originserver)
+                debugs(3, DBG_CRITICAL, "WARNING: socks4 requires originserver option on cache_peer " << p->host);
         } else if (!strcmp(token, "socks5")) {
             p->socks_type = 5;
+            if (!p->options.originserver)
+                debugs(3, DBG_CRITICAL, "WARNING: socks5 requires originserver option on cache_peer " << p->host);
         } else if (!strncmp(token, "socks-user=", 11)) {
             safe_free(p->socks_user);
             p->socks_user = xstrdup(token + 11);
         } else if (!strncmp(token, "socks-pass=", 11)) {
             safe_free(p->socks_pass);
             p->socks_pass = xstrdup(token + 11);
-'''
+        }'''
 
-# Find the anchor in a strcmp context and insert after its closing brace
-pattern = re.compile(
-    r'(else\s+if\s*\(!strcmp\(token,\s*"' + re.escape(anchor) + r'"\)\)\s*\{[^}]*\})',
-    re.DOTALL
-)
+# Find the anchor in a strcmp/strncmp context
+# Try matching "else if" variant first (most options), then plain "if" (first option)
+for pat_template in [
+    r'else\s+if\s*\(!(?:strcmp|strncmp)\(token,\s*"' + re.escape(anchor) + r'"',
+    r'if\s*\(!(?:strcmp|strncmp)\(token,\s*"' + re.escape(anchor) + r'"',
+]:
+    pat = re.compile(pat_template)
+    match = pat.search(content)
+    if match:
+        break
 
-match = pattern.search(content)
-if match:
-    insert_pos = match.end()
-    content = content[:insert_pos] + socks_code + content[insert_pos:]
-    with open(filepath, 'w') as f:
-        f.write(content)
-    print(f"    Inserted SOCKS parsing after '{anchor}' block")
-else:
-    # Fallback: brace-counting approach
-    simple = f'"{anchor}"'
-    idx = content.find(simple)
-    if idx < 0:
-        print(f"ERROR: Could not find '{anchor}' in cache_cf.cc", file=sys.stderr)
-        sys.exit(1)
-    brace_start = content.find('{', idx)
-    if brace_start < 0:
-        print("ERROR: Could not find opening brace", file=sys.stderr)
-        sys.exit(1)
-    depth = 1
-    pos = brace_start + 1
-    while pos < len(content) and depth > 0:
-        if content[pos] == '{': depth += 1
-        elif content[pos] == '}': depth -= 1
-        pos += 1
-    content = content[:pos] + socks_code + content[pos:]
-    with open(filepath, 'w') as f:
-        f.write(content)
-    print(f"    Inserted SOCKS parsing (fallback) after '{anchor}' block")
+if not match:
+    print(f"ERROR: Could not find '{anchor}' in cache_cf.cc", file=sys.stderr)
+    sys.exit(1)
+
+# From the match position, find the opening brace and count to the closing brace
+idx = match.start()
+brace_start = content.find('{', idx)
+if brace_start < 0:
+    print("ERROR: Could not find opening brace", file=sys.stderr)
+    sys.exit(1)
+depth = 1
+pos = brace_start + 1
+while pos < len(content) and depth > 0:
+    if content[pos] == '{': depth += 1
+    elif content[pos] == '}': depth -= 1
+    pos += 1
+# pos is now right after the closing "}" of the anchor block
+content = content[:pos] + socks_code + content[pos:]
+with open(filepath, 'w') as f:
+    f.write(content)
+print(f"    Inserted SOCKS parsing after '{anchor}' block")
 PYEOF
 fi
 
@@ -139,10 +142,10 @@ FWD_STATE="${SQUID_SRC}/src/FwdState.cc"
 echo "==> Patching ${FWD_STATE}"
 [ -f "${FWD_STATE}" ] || die "FwdState.cc not found"
 
-# Add include – after the first #include line (squid.h is always first)
+# Add include AFTER squid.h (squid.h MUST be the first include in every .cc)
 if ! grep -q 'SocksPeerConnector.h' "${FWD_STATE}"; then
-    sed -i '0,/#include/{s/#include/#include "SocksPeerConnector.h"\n#include/}' "${FWD_STATE}"
-    # Verify it was inserted
+    sed -i '/#include "squid.h"/a\
+#include "SocksPeerConnector.h"' "${FWD_STATE}"
     grep -q 'SocksPeerConnector.h' "${FWD_STATE}" || die "Failed to add include to FwdState.cc"
 fi
 
@@ -155,11 +158,11 @@ filepath = sys.argv[1]
 with open(filepath, 'r') as f:
     content = f.read()
 
-# Squid 6.x API:
+# Squid 6.10 API:
 #   serverConnection() returns Comm::ConnectionPointer const &
 #   ->getPeer() returns CachePeer*
 #   ->fd is int (public member of Comm::Connection)
-#   request->url.host() returns SBuf (use .c_str() for const char*)
+#   request->url.host() returns const char*
 #   request->url.port() returns unsigned short
 #   retryOrBail() is a private method of FwdState
 socks_hook = r'''
@@ -173,7 +176,7 @@ socks_hook = r'''
             if (!SocksPeerConnector::negotiate(
                     serverConnection()->fd,
                     static_cast<SocksPeerType>(sp->socks_type),
-                    std::string(request->url.host().c_str()),
+                    std::string(request->url.host()),
                     targetPort,
                     sp->socks_user ? std::string(sp->socks_user) : std::string(),
                     sp->socks_pass ? std::string(sp->socks_pass) : std::string())) {
@@ -189,7 +192,6 @@ socks_hook = r'''
 
 inserted = False
 
-# Pattern: void FwdState::dispatch()  {
 for pat in [
     r'(void\s+FwdState::dispatch\s*\(\s*\)\s*\{)',
     r'(FwdState::dispatch\s*\(\s*\)\s*\n?\s*\{)',
@@ -221,9 +223,10 @@ TUNNEL_CC="${SQUID_SRC}/src/tunnel.cc"
 echo "==> Patching ${TUNNEL_CC}"
 [ -f "${TUNNEL_CC}" ] || die "tunnel.cc not found"
 
-# Add include – after the first #include line
+# Add include AFTER squid.h
 if ! grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}"; then
-    sed -i '0,/#include/{s/#include/#include "SocksPeerConnector.h"\n#include/}' "${TUNNEL_CC}"
+    sed -i '/#include "squid.h"/a\
+#include "SocksPeerConnector.h"' "${TUNNEL_CC}"
     grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}" || die "Failed to add include to tunnel.cc"
 fi
 
@@ -236,14 +239,12 @@ filepath = sys.argv[1]
 with open(filepath, 'r') as f:
     content = f.read()
 
-# tunnel.cc API (Squid 6.x):
-#   TunnelStateData has: server.conn (Comm::ConnectionPointer), request (HttpRequestPointer)
-#   connectDone(const Comm::ConnectionPointer &conn, ...) - called after TCP connect
+# tunnel.cc API (Squid 6.10):
+#   TunnelStateData has: server.conn, request (HttpRequestPointer)
+#   connectDone(const Comm::ConnectionPointer &conn, ...) - after TCP connect
 #   conn->getPeer() returns CachePeer*
 #   conn->fd is int
-#   For originserver peers, connectDone goes to notePeerReadyToShovel() (shovels data)
-#   For non-origin peers, connectDone goes to connectToPeer() (sends HTTP CONNECT)
-#   SOCKS peers use originserver, so after SOCKS negotiation the tunnel is ready.
+#   request->url.host() returns const char*
 socks_tunnel_hook = r'''
     /* SOCKS peer: negotiate tunnel right after TCP connect */
     if (conn->getPeer() && conn->getPeer()->socks_type) {
@@ -255,7 +256,7 @@ socks_tunnel_hook = r'''
         if (!SocksPeerConnector::negotiate(
                 conn->fd,
                 static_cast<SocksPeerType>(sp->socks_type),
-                std::string(request->url.host().c_str()),
+                std::string(request->url.host()),
                 targetPort,
                 sp->socks_user ? std::string(sp->socks_user) : std::string(),
                 sp->socks_pass ? std::string(sp->socks_pass) : std::string())) {
@@ -270,12 +271,10 @@ socks_tunnel_hook = r'''
 
 inserted = False
 
-# Target: TunnelStateData::connectDone  or  tunnelConnectDone
 for pat in [
     r'(void\s+TunnelStateData::connectDone\s*\([^)]*\)\s*\{)',
     r'(TunnelStateData::connectDone\s*\([^)]*\)\s*\n?\s*\{)',
     r'(void\s+tunnelConnectDone\s*\([^)]*\)\s*\{)',
-    # Fallback: connectToPeer
     r'(void\s+TunnelStateData::connectToPeer\s*\([^)]*\)\s*\{)',
     r'(TunnelStateData::connectToPeer\s*\([^)]*\)\s*\n?\s*\{)',
 ]:

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -150,6 +150,12 @@ validation = '''
     if (p->socks_type && !p->options.originserver)
         throw TextException(ToSBuf("cache_peer ", *p, ": socks4/socks5 requires the originserver option"), Here());
 
+    /* Validate: socks-user/socks-pass only valid with socks5 and must be set together */
+    if (p->socks_type != 5 && (p->socks_user || p->socks_pass))
+        throw TextException(ToSBuf("cache_peer ", *p, ": socks-user/socks-pass options require socks5"), Here());
+    if (p->socks_type == 5 && ((!p->socks_user) != (!p->socks_pass)))
+        throw TextException(ToSBuf("cache_peer ", *p, ": socks-user and socks-pass must both be set or both omitted"), Here());
+
 '''
 marker = 'findCachePeerByName'
 marker_idx = content.find(marker, pos)

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -159,7 +159,8 @@ if marker_idx > pos:
         content = content[:line_start] + validation + content[line_start:]
         print("    Inserted SOCKS+originserver validation after option parsing loop")
 else:
-    print("WARNING: Could not insert originserver validation", file=sys.stderr)
+    print("ERROR: Could not insert originserver validation", file=sys.stderr)
+    sys.exit(1)
 
 with open(filepath, 'w') as f:
     f.write(content)
@@ -295,7 +296,8 @@ socks_tunnel_hook = r'''
                 sp->socks_user ? std::string(sp->socks_user) : std::string(),
                 sp->socks_pass ? std::string(sp->socks_pass) : std::string())) {
             debugs(26, 2, "SOCKS tunnel negotiation FAILED for " << sp->host);
-            conn->close();
+            saveError(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
+            retryOrBail("SOCKS negotiation failed");
             return;
         }
         debugs(26, 3, "SOCKS tunnel negotiation OK for " << sp->host);
@@ -336,6 +338,7 @@ echo "==> All patches applied successfully"
 echo ""
 echo "Modified files:"
 echo "  - src/CachePeer.h            (added socks_type/user/pass fields)"
+echo "  - src/CachePeer.cc           (added socks_user/pass cleanup in destructor)"
 echo "  - src/cache_cf.cc            (added socks4/socks5 option parsing)"
 echo "  - src/FwdState.cc            (SOCKS negotiation in dispatch())"
 echo "  - src/tunnel.cc              (SOCKS negotiation in connectDone())"

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -311,8 +311,6 @@ for pat in [
     r'(void\s+TunnelStateData::connectDone\s*\([^)]*\)\s*\{)',
     r'(TunnelStateData::connectDone\s*\([^)]*\)\s*\n?\s*\{)',
     r'(void\s+tunnelConnectDone\s*\([^)]*\)\s*\{)',
-    r'(void\s+TunnelStateData::connectToPeer\s*\([^)]*\)\s*\{)',
-    r'(TunnelStateData::connectToPeer\s*\([^)]*\)\s*\n?\s*\{)',
 ]:
     match = re.search(pat, content)
     if match:

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -237,8 +237,9 @@ if not inserted:
         print("    Inserted SOCKS hook (pattern 2)")
 
 if not inserted:
-    print("WARNING: Could not find dispatch() insertion point in FwdState.cc", file=sys.stderr)
-    print("         SOCKS support for HTTP requests may not work", file=sys.stderr)
+    print("ERROR: Could not find dispatch() insertion point in FwdState.cc", file=sys.stderr)
+    print("       SOCKS support for HTTP requests will not work", file=sys.stderr)
+    sys.exit(1)
 else:
     with open(filepath, 'w') as f:
         f.write(content)
@@ -352,7 +353,8 @@ if inserted:
     with open(filepath, 'w') as f:
         f.write(content)
 else:
-    print("WARNING: Could not patch tunnel.cc - HTTPS tunneling through SOCKS peers may not work", file=sys.stderr)
+    print("ERROR: Could not patch tunnel.cc - HTTPS tunneling through SOCKS peers will not work", file=sys.stderr)
+    sys.exit(1)
 
 PYEOF
 fi

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -99,7 +99,7 @@ if ! grep -q 'socks_type' "${CACHE_CF}"; then
 
     # Insert SOCKS option parsing after the first occurrence of the anchor option block
     # We use a Python script for reliable multi-line insertion
-    python3 << 'PYEOF' "${CACHE_CF}" "${ANCHOR}"
+    python3 - "${CACHE_CF}" "${ANCHOR}" << 'PYEOF'
 import sys, re
 
 filepath = sys.argv[1]
@@ -179,7 +179,7 @@ fi
 # We look for the dispatch() call that happens after peer connection
 # and add SOCKS negotiation before it.
 if ! grep -q 'socks_type' "${FWD_STATE}"; then
-    python3 << 'PYEOF' "${FWD_STATE}"
+    python3 - "${FWD_STATE}" << 'PYEOF'
 import sys, re
 
 filepath = sys.argv[1]
@@ -271,7 +271,7 @@ if ! grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}"; then
 fi
 
 if ! grep -q 'socks_type' "${TUNNEL_CC}"; then
-    python3 << 'PYEOF' "${TUNNEL_CC}"
+    python3 - "${TUNNEL_CC}" << 'PYEOF'
 import sys, re
 
 filepath = sys.argv[1]

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -210,6 +210,15 @@ socks_hook = r'''
     /* SOCKS peer negotiation: after TCP connect, before HTTP dispatch */
     if (const auto sp = serverConnection()->getPeer()) {
         if (sp->socks_type) {
+            /* The SOCKS tunnel is bound to (request->url.host():port).
+             * The pconn pool is keyed by peer address, NOT target, so a
+             * pooled SOCKS-negotiated connection would silently route the
+             * next request to the WRONG destination.  Force the upstream
+             * connection to close after this request to keep one tunnel
+             * per target, and to guarantee the next dispatch() runs on a
+             * freshly-connected fd that has not been SOCKS-negotiated yet. */
+            request->flags.proxyKeepalive = false;
+
             const auto targetPort = static_cast<uint16_t>(request->url.port());
             debugs(17, 3, "SOCKS" << sp->socks_type
                    << " negotiation with peer " << sp->host
@@ -290,6 +299,11 @@ socks_tunnel_hook = r'''
     /* SOCKS peer: negotiate tunnel right after TCP connect */
     if (conn->getPeer() && conn->getPeer()->socks_type) {
         const auto sp = conn->getPeer();
+        /* Same rationale as FwdState::dispatch(): the SOCKS tunnel is
+         * bound to one target host, so prevent this connection from being
+         * returned to the pconn pool where another request could pick it
+         * up and silently send data into the previous target's tunnel. */
+        request->flags.proxyKeepalive = false;
         const auto targetPort = static_cast<uint16_t>(request->url.port());
         debugs(26, 3, "SOCKS" << sp->socks_type
                << " tunnel negotiation with peer " << sp->host

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -280,8 +280,17 @@ socks_hook = r'''
              * live stream, and using it as-is would silently mis-route this
              * request.  Drop it and let FwdState retry on a fresh fd. */
             if (serverConnection()->socksNegotiated) {
-                debugs(17, 2, "SOCKS: peer connection to " << sp->host
-                       << " already negotiated; retrying on a fresh connection");
+                /* A reused, already-negotiated pconn is a tunnel bound to a
+                 * previous target.  Tear it down before retrying: noteConnection()
+                 * has already set destinationReceipt and syncWithServerConn() has
+                 * installed serverConn/closeHandler, so a bare retryOrBail() would
+                 * re-enter noteConnection() with destinationReceipt still set and
+                 * trip assert(!destinationReceipt).  Mirror serverClosed(). */
+                debugs(17, 2, "SOCKS: dropping reused negotiated connection to "
+                       << sp->host << "; retrying on a fresh fd");
+                closeServerConnection("reused SOCKS tunnel cannot serve a new target");
+                serverConn = nullptr;
+                destinationReceipt = nullptr;
                 retryOrBail();
                 return;
             }
@@ -307,6 +316,9 @@ socks_hook = r'''
                     sp->socks_user ? std::string(sp->socks_user) : std::string(),
                     sp->socks_pass ? std::string(sp->socks_pass) : std::string())) {
                 debugs(17, 2, "SOCKS negotiation FAILED for peer " << sp->host);
+                closeServerConnection("SOCKS negotiation failed");
+                serverConn = nullptr;
+                destinationReceipt = nullptr;
                 retryOrBail();
                 return;
             }
@@ -379,8 +391,12 @@ socks_tunnel_hook = r'''
         /* Anti-reuse guard: never re-negotiate (or reuse) a connection that
          * already carries a SOCKS tunnel to a previous target. */
         if (conn->socksNegotiated) {
-            debugs(26, 2, "SOCKS: tunnel peer connection to " << sp->host
-                   << " already negotiated; reconnecting");
+            /* Reused tunnel connection already bound to a previous target:
+             * close the pending conn (server.conn is still nil here) before
+             * retrying, matching tunnel.cc's other error paths. */
+            debugs(26, 2, "SOCKS: dropping reused negotiated tunnel connection to "
+                   << sp->host << "; retrying");
+            closePendingConnection(conn, "reused SOCKS tunnel cannot serve a new target");
             saveError(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
             retryOrBail("SOCKS tunnel reuse");
             return;
@@ -402,6 +418,7 @@ socks_tunnel_hook = r'''
                 sp->socks_user ? std::string(sp->socks_user) : std::string(),
                 sp->socks_pass ? std::string(sp->socks_pass) : std::string())) {
             debugs(26, 2, "SOCKS tunnel negotiation FAILED for " << sp->host);
+            closePendingConnection(conn, "SOCKS negotiation failed");
             saveError(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
             retryOrBail("SOCKS negotiation failed");
             return;

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -52,6 +52,24 @@ fi
 echo "    CachePeer.h patched OK"
 
 # ---------------------------------------------------------------------------
+# 1b. CachePeer.cc  –  free socks_user / socks_pass in destructor
+# ---------------------------------------------------------------------------
+CACHE_PEER_CC="${SQUID_SRC}/src/CachePeer.cc"
+echo "==> Patching ${CACHE_PEER_CC}"
+[ -f "${CACHE_PEER_CC}" ] || die "CachePeer.cc not found"
+
+if ! grep -q 'socks_user' "${CACHE_PEER_CC}"; then
+    # Insert xfree calls next to existing xfree(login) in the destructor
+    sed -i '/xfree(login);/a\
+\
+    xfree(socks_user);\
+    xfree(socks_pass);' "${CACHE_PEER_CC}"
+    grep -q 'socks_user' "${CACHE_PEER_CC}" || die "Failed to patch CachePeer.cc destructor"
+fi
+
+echo "    CachePeer.cc patched OK"
+
+# ---------------------------------------------------------------------------
 # 2. cache_cf.cc  –  parse socks4 / socks5 / socks-user= / socks-pass=
 # ---------------------------------------------------------------------------
 CACHE_CF="${SQUID_SRC}/src/cache_cf.cc"
@@ -84,12 +102,8 @@ with open(filepath, 'r') as f:
 # that closes the anchor's if-block, so " else if" continues the chain.
 socks_code = ''' else if (!strcmp(token, "socks4")) {
             p->socks_type = 4;
-            if (!p->options.originserver)
-                debugs(3, DBG_CRITICAL, "WARNING: socks4 requires originserver option on cache_peer " << p->host);
         } else if (!strcmp(token, "socks5")) {
             p->socks_type = 5;
-            if (!p->options.originserver)
-                debugs(3, DBG_CRITICAL, "WARNING: socks5 requires originserver option on cache_peer " << p->host);
         } else if (!strncmp(token, "socks-user=", 11)) {
             safe_free(p->socks_user);
             p->socks_user = xstrdup(token + 11);
@@ -127,6 +141,26 @@ while pos < len(content) and depth > 0:
     pos += 1
 # pos is now right after the closing "}" of the anchor block
 content = content[:pos] + socks_code + content[pos:]
+
+# Also add a post-parse validation: socks4/socks5 requires originserver.
+# Options can appear in any order, so we validate after the while loop ends.
+# findCachePeerByName is the first check after the option-parsing loop.
+validation = '''
+    /* Validate: SOCKS peers must use originserver */
+    if (p->socks_type && !p->options.originserver)
+        throw TextException(ToSBuf("cache_peer ", *p, ": socks4/socks5 requires the originserver option"), Here());
+
+'''
+marker = 'findCachePeerByName'
+marker_idx = content.find(marker, pos)
+if marker_idx > pos:
+    line_start = content.rfind('\n', 0, marker_idx)
+    if line_start > 0:
+        content = content[:line_start] + validation + content[line_start:]
+        print("    Inserted SOCKS+originserver validation after option parsing loop")
+else:
+    print("WARNING: Could not insert originserver validation", file=sys.stderr)
+
 with open(filepath, 'w') as f:
     f.write(content)
 print(f"    Inserted SOCKS parsing after '{anchor}' block")

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -1,0 +1,383 @@
+#!/bin/bash
+#
+# patch_apply.sh - Apply SOCKS cache_peer support patches to Squid source
+#
+# Usage: patch_apply.sh <patch_src_dir> <squid_src_dir>
+#
+# This script modifies the Squid source tree to add SOCKS4/SOCKS5
+# support for cache_peer directives.  It uses pattern-based sed
+# modifications so that it is tolerant of minor whitespace changes
+# across point releases of the same major version.
+#
+set -euo pipefail
+
+PATCH_SRC="${1:?Usage: $0 <patch_src_dir> <squid_src_dir>}"
+SQUID_SRC="${2:?Usage: $0 <patch_src_dir> <squid_src_dir>}"
+
+die() { echo "PATCH ERROR: $*" >&2; exit 1; }
+
+echo "==> Copying SocksPeerConnector.h into ${SQUID_SRC}/src/"
+cp "${PATCH_SRC}/SocksPeerConnector.h" "${SQUID_SRC}/src/SocksPeerConnector.h" \
+    || die "Failed to copy SocksPeerConnector.h"
+
+# ---------------------------------------------------------------------------
+# 1. CachePeer.h  –  add socks_type / socks_user / socks_pass fields
+# ---------------------------------------------------------------------------
+CACHE_PEER_H="${SQUID_SRC}/src/CachePeer.h"
+echo "==> Patching ${CACHE_PEER_H}"
+[ -f "${CACHE_PEER_H}" ] || die "CachePeer.h not found"
+
+# Verify the file contains the struct we expect
+grep -q 'class CachePeer' "${CACHE_PEER_H}" || die "CachePeer class not found"
+
+# Add include for SocksPeerConnector.h and string after existing includes
+if ! grep -q 'SocksPeerConnector.h' "${CACHE_PEER_H}"; then
+    sed -i '/#ifndef SQUID_SRC_CACHEPEER_H/,/#define SQUID_SRC_CACHEPEER_H/{
+        /#define SQUID_SRC_CACHEPEER_H/a\
+\
+#include "SocksPeerConnector.h"\
+#include <string>
+    }' "${CACHE_PEER_H}"
+fi
+
+# Add SOCKS fields to CachePeer class – insert before the closing brace + semicolon
+# We look for a known member and add after it, or add before the end of the class
+if ! grep -q 'socks_type' "${CACHE_PEER_H}"; then
+    # Find "} options;" line (the options struct closing) and add SOCKS fields after it
+    if grep -q '} options;' "${CACHE_PEER_H}" 2>/dev/null; then
+        sed -i '/} options;/a\
+\
+    /* SOCKS proxy support for cache_peer */\
+    SocksPeerType socks_type = SOCKS_NONE;\
+    std::string socks_user;\
+    std::string socks_pass;' "${CACHE_PEER_H}"
+    else
+        # Fallback: add before the last closing brace of the class
+        # Find "CBDATA_CLASS" or last "};" and insert before it
+        sed -i '/^};/i\
+\
+    /* SOCKS proxy support for cache_peer */\
+    SocksPeerType socks_type = SOCKS_NONE;\
+    std::string socks_user;\
+    std::string socks_pass;\
+' "${CACHE_PEER_H}"
+    fi
+fi
+
+echo "    CachePeer.h patched OK"
+
+# ---------------------------------------------------------------------------
+# 2. cache_cf.cc  –  parse socks4 / socks5 / socks-user= / socks-pass=
+# ---------------------------------------------------------------------------
+CACHE_CF="${SQUID_SRC}/src/cache_cf.cc"
+echo "==> Patching ${CACHE_CF}"
+[ -f "${CACHE_CF}" ] || die "cache_cf.cc not found"
+
+if ! grep -q 'socks_type' "${CACHE_CF}"; then
+    # Find the peer option parsing block. In Squid 6.x, options are parsed
+    # in a loop that checks token values like "no-query", "proxy-only", etc.
+    # We add our SOCKS options alongside the existing option parsing.
+    #
+    # Strategy: find the pattern 'strcmp(token, "proxy-only")' or similar
+    # well-known option and add our parsing block after the closing brace
+    # of that if-block.
+
+    # Try to find a good anchor point
+    ANCHOR=""
+    for pattern in 'proxy-only' 'no-digest' 'no-query' 'round-robin' 'originserver'; do
+        if grep -q "\"${pattern}\"" "${CACHE_CF}"; then
+            ANCHOR="${pattern}"
+            break
+        fi
+    done
+
+    if [ -z "${ANCHOR}" ]; then
+        die "Could not find peer option parsing anchor in cache_cf.cc"
+    fi
+
+    echo "    Using anchor: '${ANCHOR}'"
+
+    # Insert SOCKS option parsing after the first occurrence of the anchor option block
+    # We use a Python script for reliable multi-line insertion
+    python3 << 'PYEOF' "${CACHE_CF}" "${ANCHOR}"
+import sys, re
+
+filepath = sys.argv[1]
+anchor = sys.argv[2]
+
+with open(filepath, 'r') as f:
+    content = f.read()
+
+socks_code = '''
+        } else if (!strcmp(token, "socks4")) {
+            p->socks_type = SOCKS_V4;
+        } else if (!strcmp(token, "socks5")) {
+            p->socks_type = SOCKS_V5;
+        } else if (!strncmp(token, "socks-user=", 11)) {
+            p->socks_user = token + 11;
+        } else if (!strncmp(token, "socks-pass=", 11)) {
+            p->socks_pass = token + 11;
+'''
+
+# Find the anchor pattern in a strcmp context
+pattern = re.compile(
+    r'(else\s+if\s*\(!strcmp\(token,\s*"' + re.escape(anchor) + r'"\)\)\s*\{[^}]*\})',
+    re.DOTALL
+)
+
+match = pattern.search(content)
+if match:
+    insert_pos = match.end()
+    content = content[:insert_pos] + socks_code + content[insert_pos:]
+    with open(filepath, 'w') as f:
+        f.write(content)
+    print(f"    Inserted SOCKS parsing after '{anchor}' block")
+else:
+    # Fallback: search for simpler pattern
+    simple = f'"{anchor}"'
+    idx = content.find(simple)
+    if idx < 0:
+        print(f"ERROR: Could not find '{anchor}' in cache_cf.cc", file=sys.stderr)
+        sys.exit(1)
+    # Find the closing brace of this if block
+    brace_start = content.find('{', idx)
+    if brace_start < 0:
+        print("ERROR: Could not find opening brace", file=sys.stderr)
+        sys.exit(1)
+    depth = 1
+    pos = brace_start + 1
+    while pos < len(content) and depth > 0:
+        if content[pos] == '{': depth += 1
+        elif content[pos] == '}': depth -= 1
+        pos += 1
+    content = content[:pos] + socks_code + content[pos:]
+    with open(filepath, 'w') as f:
+        f.write(content)
+    print(f"    Inserted SOCKS parsing (fallback) after '{anchor}' block")
+PYEOF
+fi
+
+echo "    cache_cf.cc patched OK"
+
+# ---------------------------------------------------------------------------
+# 3. FwdState.cc  –  SOCKS negotiation after TCP connect (HTTP requests)
+# ---------------------------------------------------------------------------
+FWD_STATE="${SQUID_SRC}/src/FwdState.cc"
+echo "==> Patching ${FWD_STATE}"
+[ -f "${FWD_STATE}" ] || die "FwdState.cc not found"
+
+# Add include
+if ! grep -q 'SocksPeerConnector.h' "${FWD_STATE}"; then
+    sed -i '/#include "FwdState.h"/a\
+#include "SocksPeerConnector.h"' "${FWD_STATE}"
+fi
+
+# Add SOCKS negotiation hook.
+# In Squid 6.x, after connection is established to a peer, the code
+# eventually calls dispatch(). We insert SOCKS negotiation before dispatch.
+#
+# We look for the dispatch() call that happens after peer connection
+# and add SOCKS negotiation before it.
+if ! grep -q 'socks_type' "${FWD_STATE}"; then
+    python3 << 'PYEOF' "${FWD_STATE}"
+import sys, re
+
+filepath = sys.argv[1]
+
+with open(filepath, 'r') as f:
+    content = f.read()
+
+socks_hook = r'''
+    /* SOCKS peer negotiation: after TCP connect, before dispatch */
+    if (serverConnection()->getPeer() &&
+        serverConnection()->getPeer()->socks_type != SOCKS_NONE) {
+        CachePeer *sp = serverConnection()->getPeer();
+        const char *targetHost = request->url.host();
+        const uint16_t targetPort = request->url.port();
+        debugs(17, 3, "SOCKS" << (int)sp->socks_type
+               << " negotiation with peer " << sp->host
+               << " for " << targetHost << ":" << targetPort);
+        if (!SocksPeerConnector::negotiate(
+                serverConnection()->fd,
+                sp->socks_type,
+                std::string(targetHost),
+                targetPort,
+                sp->socks_user,
+                sp->socks_pass)) {
+            debugs(17, 2, "SOCKS negotiation FAILED for peer " << sp->host);
+            retryOrBail();
+            return;
+        }
+        debugs(17, 3, "SOCKS negotiation OK for peer " << sp->host);
+    }
+
+'''
+
+# Strategy: find the dispatch() call in a connected-to-peer context
+# Look for "dispatch()" preceded by peer-related code
+# Multiple possible patterns across Squid versions
+
+inserted = False
+
+# Pattern 1: Look for "void FwdState::dispatch()" and insert at the top of the function
+match = re.search(r'(void\s+FwdState::dispatch\s*\(\s*\)\s*\{)', content)
+if match:
+    insert_pos = match.end()
+    content = content[:insert_pos] + socks_hook + content[insert_pos:]
+    inserted = True
+    print("    Inserted SOCKS hook at top of FwdState::dispatch()")
+
+if not inserted:
+    # Pattern 2: look for "FwdState::dispatch" with different formatting
+    match = re.search(r'(FwdState::dispatch\(\)\s*\n?\{)', content)
+    if match:
+        insert_pos = match.end()
+        content = content[:insert_pos] + socks_hook + content[insert_pos:]
+        inserted = True
+        print("    Inserted SOCKS hook (pattern 2)")
+
+if not inserted:
+    print("WARNING: Could not find dispatch() insertion point in FwdState.cc", file=sys.stderr)
+    print("         SOCKS support for HTTP requests may not work", file=sys.stderr)
+else:
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+PYEOF
+fi
+
+echo "    FwdState.cc patched OK"
+
+# ---------------------------------------------------------------------------
+# 4. tunnel.cc  –  SOCKS negotiation for CONNECT / HTTPS tunneling
+# ---------------------------------------------------------------------------
+TUNNEL_CC="${SQUID_SRC}/src/tunnel.cc"
+echo "==> Patching ${TUNNEL_CC}"
+[ -f "${TUNNEL_CC}" ] || die "tunnel.cc not found"
+
+if ! grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}"; then
+    # Add include near the top
+    sed -i '/#include "tunnel.h"\|#include "squid.h"\|#include "base\//{
+        /#include "squid.h"/a\
+#include "SocksPeerConnector.h"
+    }' "${TUNNEL_CC}"
+    # Fallback: if the above didn't match, try another pattern
+    if ! grep -q 'SocksPeerConnector.h' "${TUNNEL_CC}"; then
+        sed -i '1,/^#include/{
+            /^#include/a\
+#include "SocksPeerConnector.h"
+        }' "${TUNNEL_CC}"
+    fi
+fi
+
+if ! grep -q 'socks_type' "${TUNNEL_CC}"; then
+    python3 << 'PYEOF' "${TUNNEL_CC}"
+import sys, re
+
+filepath = sys.argv[1]
+
+with open(filepath, 'r') as f:
+    content = f.read()
+
+# In tunnel.cc, after connecting to a peer for CONNECT requests,
+# Squid sends "CONNECT host:port HTTP/1.1" to the peer.
+# For SOCKS peers, we need to do SOCKS negotiation instead.
+#
+# Look for the function that sends the CONNECT request to the peer.
+# Common function names: connectToPeer(), tunnelConnectDone(),
+# connectedToPeer(), writeServerConnect(), etc.
+
+socks_tunnel_hook = r'''
+    /* SOCKS peer: negotiate tunnel instead of HTTP CONNECT */
+    if (serverConnection()->getPeer() &&
+        serverConnection()->getPeer()->socks_type != SOCKS_NONE) {
+        CachePeer *sp = serverConnection()->getPeer();
+        const char *tHost = request->url.host();
+        const uint16_t tPort = request->url.port();
+        debugs(26, 3, "SOCKS" << (int)sp->socks_type
+               << " tunnel negotiation with peer " << sp->host
+               << " for " << tHost << ":" << tPort);
+        if (!SocksPeerConnector::negotiate(
+                serverConnection()->fd,
+                sp->socks_type,
+                std::string(tHost),
+                tPort,
+                sp->socks_user,
+                sp->socks_pass)) {
+            debugs(26, 2, "SOCKS tunnel negotiation FAILED for " << sp->host);
+            ErrorState *err = new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al);
+            fail(err);
+            closeServerConnection("SOCKS negotiation failed");
+            return;
+        }
+        debugs(26, 3, "SOCKS tunnel negotiation OK for " << sp->host);
+        /* After SOCKS negotiation, connection is a direct tunnel.
+         * Skip the HTTP CONNECT and go straight to relaying. */
+        connectExchangeCheckpoint();
+        return;
+    }
+
+'''
+
+inserted = False
+
+# Look for the point where HTTP CONNECT is sent to peer
+# Pattern: a function that handles "connected to peer" and sends CONNECT
+for func_pattern in [
+    r'(void\s+TunnelStateData::connectToPeer\s*\([^)]*\)\s*\{)',
+    r'(TunnelStateData::connectedToPeer\s*\([^)]*\)\s*\{)',
+    r'(void\s+tunnelConnectDone\s*\([^)]*\)\s*\{)',
+    r'(TunnelStateData::sendConnectRequest\s*\([^)]*\)\s*\{)',
+    r'(TunnelStateData::noteConnection\s*\([^)]*\)\s*\{)',
+]:
+    match = re.search(func_pattern, content)
+    if match:
+        insert_pos = match.end()
+        content = content[:insert_pos] + socks_tunnel_hook + content[insert_pos:]
+        inserted = True
+        print(f"    Inserted SOCKS tunnel hook in {match.group(0)[:60]}...")
+        break
+
+if not inserted:
+    # Last resort: find any function with "peer" and "connect" in tunnel.cc
+    # and add the hook there
+    match = re.search(r'(void\s+\w+::\w*[Cc]onnect\w*\s*\([^)]*\)\s*\{)', content)
+    if match:
+        insert_pos = match.end()
+        content = content[:insert_pos] + socks_tunnel_hook + content[insert_pos:]
+        inserted = True
+        print(f"    Inserted SOCKS tunnel hook (fallback) in {match.group(0)[:60]}...")
+
+if inserted:
+    with open(filepath, 'w') as f:
+        f.write(content)
+else:
+    print("WARNING: Could not patch tunnel.cc - HTTPS tunneling through SOCKS peers may not work", file=sys.stderr)
+
+PYEOF
+fi
+
+echo "    tunnel.cc patched OK"
+
+# ---------------------------------------------------------------------------
+# 5. HttpStateData  –  use origin-server request format for SOCKS peers
+# ---------------------------------------------------------------------------
+# For SOCKS peers, after the SOCKS tunnel is established the connection
+# is effectively direct to the origin server. We must send requests in
+# origin format (GET /path) rather than proxy format (GET http://host/path).
+#
+# In Squid this is controlled by the CachePeer::options.originserver flag.
+# Rather than modifying HttpStateData, we set originserver = true for SOCKS
+# peers during configuration parsing (in cache_cf.cc).  This is already
+# handled because the Dockerfile squid.conf template uses the "originserver"
+# option explicitly.
+
+echo ""
+echo "==> All patches applied successfully"
+echo ""
+echo "Modified files:"
+echo "  - src/CachePeer.h       (added socks_type/user/pass fields)"
+echo "  - src/cache_cf.cc       (added socks4/socks5 option parsing)"
+echo "  - src/FwdState.cc       (added SOCKS negotiation before dispatch)"
+echo "  - src/tunnel.cc         (added SOCKS negotiation for CONNECT tunneling)"
+echo "  - src/SocksPeerConnector.h (new: SOCKS4/5 protocol implementation)"

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -70,6 +70,70 @@ fi
 echo "    CachePeer.cc patched OK"
 
 # ---------------------------------------------------------------------------
+# 1c. comm/Connection.h  –  add socksNegotiated flag (SOCKS anti-reuse guard)
+# ---------------------------------------------------------------------------
+# A SOCKS-negotiated cache_peer connection is a raw tunnel bound to ONE target
+# (request->url.host():port).  The persistent-connection pool is keyed by peer,
+# NOT target, so a pooled SOCKS connection could otherwise be reused for a
+# different target (silent mis-routing) or receive a second SOCKS greeting
+# injected into a live stream.  This per-connection flag lets the FwdState /
+# tunnel hooks detect and refuse such reuse.
+CONNECTION_H="${SQUID_SRC}/src/comm/Connection.h"
+echo "==> Patching ${CONNECTION_H}"
+[ -f "${CONNECTION_H}" ] || die "comm/Connection.h not found"
+
+if ! grep -q 'socksNegotiated' "${CONNECTION_H}"; then
+    python3 - "${CONNECTION_H}" << 'PYEOF'
+import sys, re
+
+filepath = sys.argv[1]
+with open(filepath, 'r') as f:
+    content = f.read()
+
+# Locate the *definition* of class Connection (skip forward declarations like
+# "class Connection;").  A definition has an opening "{" before any ";".
+match = None
+brace_start = -1
+for mm in re.finditer(r'class\s+Connection\b', content):
+    rest = content[mm.end():]
+    brace = rest.find('{')
+    semi = rest.find(';')
+    if brace != -1 and (semi == -1 or brace < semi):
+        match = mm
+        brace_start = mm.end() + brace
+        break
+
+if match is None:
+    print("ERROR: class Connection definition not found in Connection.h", file=sys.stderr)
+    sys.exit(1)
+
+# Brace-match to find the closing "}" of the class body.
+depth = 1
+pos = brace_start + 1
+while pos < len(content) and depth > 0:
+    if content[pos] == '{': depth += 1
+    elif content[pos] == '}': depth -= 1
+    pos += 1
+
+# pos is right after the closing "}"; insert the field just before it.
+field = ('\npublic:\n'
+         '    /* SOCKS peer support: true once SocksPeerConnector has\n'
+         '     * negotiated a tunnel on this fd.  Prevents a pooled SOCKS\n'
+         '     * tunnel (bound to one target) from being reused for another. */\n'
+         '    bool socksNegotiated = false;\n')
+insert_at = pos - 1
+content = content[:insert_at] + field + content[insert_at:]
+
+with open(filepath, 'w') as f:
+    f.write(content)
+print("    Inserted socksNegotiated flag into class Connection")
+PYEOF
+    grep -q 'socksNegotiated' "${CONNECTION_H}" || die "Failed to add socksNegotiated to Connection.h"
+fi
+
+echo "    comm/Connection.h patched OK"
+
+# ---------------------------------------------------------------------------
 # 2. cache_cf.cc  –  parse socks4 / socks5 / socks-user= / socks-pass=
 # ---------------------------------------------------------------------------
 CACHE_CF="${SQUID_SRC}/src/cache_cf.cc"
@@ -210,6 +274,18 @@ socks_hook = r'''
     /* SOCKS peer negotiation: after TCP connect, before HTTP dispatch */
     if (const auto sp = serverConnection()->getPeer()) {
         if (sp->socks_type) {
+            /* Anti-reuse guard: a connection that has already been
+             * SOCKS-negotiated is a pooled tunnel bound to a *previous*
+             * target.  Re-negotiating would inject a second greeting into a
+             * live stream, and using it as-is would silently mis-route this
+             * request.  Drop it and let FwdState retry on a fresh fd. */
+            if (serverConnection()->socksNegotiated) {
+                debugs(17, 2, "SOCKS: peer connection to " << sp->host
+                       << " already negotiated; retrying on a fresh connection");
+                retryOrBail();
+                return;
+            }
+
             /* The SOCKS tunnel is bound to (request->url.host():port).
              * The pconn pool is keyed by peer address, NOT target, so a
              * pooled SOCKS-negotiated connection would silently route the
@@ -234,6 +310,7 @@ socks_hook = r'''
                 retryOrBail();
                 return;
             }
+            serverConnection()->socksNegotiated = true;
             debugs(17, 3, "SOCKS negotiation OK for peer " << sp->host);
         }
     }
@@ -299,6 +376,15 @@ socks_tunnel_hook = r'''
     /* SOCKS peer: negotiate tunnel right after TCP connect */
     if (conn->getPeer() && conn->getPeer()->socks_type) {
         const auto sp = conn->getPeer();
+        /* Anti-reuse guard: never re-negotiate (or reuse) a connection that
+         * already carries a SOCKS tunnel to a previous target. */
+        if (conn->socksNegotiated) {
+            debugs(26, 2, "SOCKS: tunnel peer connection to " << sp->host
+                   << " already negotiated; reconnecting");
+            saveError(new ErrorState(ERR_CONNECT_FAIL, Http::scBadGateway, request.getRaw(), al));
+            retryOrBail("SOCKS tunnel reuse");
+            return;
+        }
         /* Same rationale as FwdState::dispatch(): the SOCKS tunnel is
          * bound to one target host, so prevent this connection from being
          * returned to the pconn pool where another request could pick it
@@ -320,6 +406,7 @@ socks_tunnel_hook = r'''
             retryOrBail("SOCKS negotiation failed");
             return;
         }
+        conn->socksNegotiated = true;
         debugs(26, 3, "SOCKS tunnel negotiation OK for " << sp->host);
     }
 
@@ -357,6 +444,7 @@ echo ""
 echo "Modified files:"
 echo "  - src/CachePeer.h            (added socks_type/user/pass fields)"
 echo "  - src/CachePeer.cc           (added socks_user/pass cleanup in destructor)"
+echo "  - src/comm/Connection.h      (added socksNegotiated anti-reuse flag)"
 echo "  - src/cache_cf.cc            (added socks4/socks5 option parsing)"
 echo "  - src/FwdState.cc            (SOCKS negotiation in dispatch())"
 echo "  - src/tunnel.cc              (SOCKS negotiation in connectDone())"

--- a/squid_patch/src/SocksPeerConnector.h
+++ b/squid_patch/src/SocksPeerConnector.h
@@ -1,0 +1,279 @@
+/*
+ * SocksPeerConnector.h - SOCKS4/SOCKS5 negotiation for Squid cache_peer
+ *
+ * Performs synchronous SOCKS handshake on an established TCP connection.
+ * After negotiation, the connection acts as a direct tunnel to the target.
+ *
+ * Reference: https://wiki.squid-cache.org/Features/Socks
+ * SOCKS4:  RFC 1928 predecessor (de facto standard)
+ * SOCKS4a: Extension for hostname resolution by proxy
+ * SOCKS5:  RFC 1928 + RFC 1929 (username/password auth)
+ */
+
+#ifndef SQUID_SRC_SOCKS_PEER_CONNECTOR_H
+#define SQUID_SRC_SOCKS_PEER_CONNECTOR_H
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <cerrno>
+#include <string>
+
+enum SocksPeerType {
+    SOCKS_NONE = 0,
+    SOCKS_V4 = 4,
+    SOCKS_V5 = 5
+};
+
+namespace SocksPeerConnector {
+
+/* ---- low-level helpers ------------------------------------------------ */
+
+static inline bool syncSend(int fd, const void *buf, size_t len)
+{
+    const char *p = static_cast<const char *>(buf);
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = ::send(fd, p + sent, len - sent, MSG_NOSIGNAL);
+        if (n <= 0)
+            return false;
+        sent += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+static inline bool syncRecv(int fd, void *buf, size_t len)
+{
+    char *p = static_cast<char *>(buf);
+    size_t got = 0;
+    while (got < len) {
+        ssize_t n = ::recv(fd, p + got, len - got, 0);
+        if (n <= 0)
+            return false;
+        got += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+/* ---- SOCKS4 / SOCKS4a ------------------------------------------------ */
+
+static inline bool socks4Connect(int fd,
+                                  const std::string &host, uint16_t port,
+                                  const std::string &user)
+{
+    struct in_addr addr;
+    bool useSocks4a = (inet_pton(AF_INET, host.c_str(), &addr) != 1);
+
+    if (useSocks4a) {
+        /* SOCKS4a: set IP to 0.0.0.x (x != 0) and append hostname */
+        addr.s_addr = htonl(0x00000001);
+    }
+
+    uint8_t req[600];
+    size_t pos = 0;
+
+    req[pos++] = 0x04;                          /* VN  = 4             */
+    req[pos++] = 0x01;                          /* CD  = CONNECT       */
+    req[pos++] = static_cast<uint8_t>((port >> 8) & 0xFF);
+    req[pos++] = static_cast<uint8_t>(port & 0xFF);
+    std::memcpy(req + pos, &addr.s_addr, 4);    /* DSTIP               */
+    pos += 4;
+
+    /* USERID */
+    if (!user.empty()) {
+        std::memcpy(req + pos, user.c_str(), user.length());
+        pos += user.length();
+    }
+    req[pos++] = 0x00;                          /* NULL terminator     */
+
+    /* SOCKS4a hostname */
+    if (useSocks4a) {
+        std::memcpy(req + pos, host.c_str(), host.length());
+        pos += host.length();
+        req[pos++] = 0x00;
+    }
+
+    if (!syncSend(fd, req, pos))
+        return false;
+
+    uint8_t resp[8];
+    if (!syncRecv(fd, resp, 8))
+        return false;
+
+    return (resp[1] == 0x5A);                   /* 0x5A = granted      */
+}
+
+/* ---- SOCKS5  (RFC 1928 + RFC 1929) ----------------------------------- */
+
+static inline bool socks5Connect(int fd,
+                                  const std::string &host, uint16_t port,
+                                  const std::string &user,
+                                  const std::string &pass)
+{
+    const bool hasAuth = (!user.empty() && !pass.empty());
+
+    /* --- greeting ---------------------------------------------------- */
+    uint8_t greeting[4];
+    size_t gLen;
+    if (hasAuth) {
+        greeting[0] = 0x05;   /* VER                     */
+        greeting[1] = 0x02;   /* NMETHODS                */
+        greeting[2] = 0x00;   /* NO AUTHENTICATION       */
+        greeting[3] = 0x02;   /* USERNAME / PASSWORD      */
+        gLen = 4;
+    } else {
+        greeting[0] = 0x05;
+        greeting[1] = 0x01;
+        greeting[2] = 0x00;
+        gLen = 3;
+    }
+
+    if (!syncSend(fd, greeting, gLen))
+        return false;
+
+    uint8_t gResp[2];
+    if (!syncRecv(fd, gResp, 2))
+        return false;
+
+    if (gResp[0] != 0x05)
+        return false;
+
+    /* --- authentication (RFC 1929) ----------------------------------- */
+    if (gResp[1] == 0x02) {
+        if (!hasAuth)
+            return false;
+
+        uint8_t auth[515];
+        size_t aPos = 0;
+        auth[aPos++] = 0x01;  /* sub-negotiation VER */
+        auth[aPos++] = static_cast<uint8_t>(user.length());
+        std::memcpy(auth + aPos, user.c_str(), user.length());
+        aPos += user.length();
+        auth[aPos++] = static_cast<uint8_t>(pass.length());
+        std::memcpy(auth + aPos, pass.c_str(), pass.length());
+        aPos += pass.length();
+
+        if (!syncSend(fd, auth, aPos))
+            return false;
+
+        uint8_t aResp[2];
+        if (!syncRecv(fd, aResp, 2))
+            return false;
+
+        if (aResp[1] != 0x00)
+            return false;   /* auth failed */
+
+    } else if (gResp[1] == 0xFF) {
+        return false;       /* no acceptable method */
+    }
+    /* else gResp[1] == 0x00 → no auth required */
+
+    /* --- connect request --------------------------------------------- */
+    uint8_t connReq[263];
+    size_t cPos = 0;
+
+    connReq[cPos++] = 0x05;   /* VER                  */
+    connReq[cPos++] = 0x01;   /* CMD = CONNECT        */
+    connReq[cPos++] = 0x00;   /* RSV                  */
+    connReq[cPos++] = 0x03;   /* ATYP = DOMAINNAME    */
+    connReq[cPos++] = static_cast<uint8_t>(host.length());
+    std::memcpy(connReq + cPos, host.c_str(), host.length());
+    cPos += host.length();
+    connReq[cPos++] = static_cast<uint8_t>((port >> 8) & 0xFF);
+    connReq[cPos++] = static_cast<uint8_t>(port & 0xFF);
+
+    if (!syncSend(fd, connReq, cPos))
+        return false;
+
+    /* --- connect response -------------------------------------------- */
+    uint8_t cResp[4];
+    if (!syncRecv(fd, cResp, 4))
+        return false;
+
+    if (cResp[0] != 0x05 || cResp[1] != 0x00)
+        return false;   /* connection failed */
+
+    /* drain the BND.ADDR + BND.PORT */
+    switch (cResp[3]) {
+    case 0x01: {            /* IPv4  */
+        uint8_t skip[6];    /* 4 addr + 2 port */
+        if (!syncRecv(fd, skip, 6)) return false;
+        break;
+    }
+    case 0x03: {            /* DOMAINNAME */
+        uint8_t dLen;
+        if (!syncRecv(fd, &dLen, 1)) return false;
+        uint8_t skip[258];
+        if (!syncRecv(fd, skip, dLen + 2)) return false;
+        break;
+    }
+    case 0x04: {            /* IPv6 */
+        uint8_t skip[18];   /* 16 addr + 2 port */
+        if (!syncRecv(fd, skip, 18)) return false;
+        break;
+    }
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+/* ---- public entry point ---------------------------------------------- */
+
+/**
+ * Perform SOCKS negotiation on an established TCP connection.
+ *
+ * Temporarily switches the socket to blocking mode, performs the
+ * SOCKS handshake (with a 10-second timeout), and restores the
+ * original socket flags.
+ *
+ * @return true on success; the fd is then a tunnel to targetHost:targetPort
+ */
+static inline bool negotiate(int fd, SocksPeerType type,
+                              const std::string &targetHost,
+                              uint16_t targetPort,
+                              const std::string &user = "",
+                              const std::string &pass = "")
+{
+    if (type == SOCKS_NONE)
+        return true;
+
+    /* save original flags */
+    int flags = fcntl(fd, F_GETFL);
+    if (flags < 0)
+        return false;
+
+    /* switch to blocking for the handshake */
+    if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0)
+        return false;
+
+    /* set a 10 s timeout so we don't hang forever */
+    struct timeval tv;
+    tv.tv_sec  = 10;
+    tv.tv_usec = 0;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    bool ok = false;
+    if (type == SOCKS_V4)
+        ok = socks4Connect(fd, targetHost, targetPort, user);
+    else if (type == SOCKS_V5)
+        ok = socks5Connect(fd, targetHost, targetPort, user, pass);
+
+    /* restore non-blocking + clear timeouts */
+    fcntl(fd, F_SETFL, flags);
+    tv.tv_sec = 0;
+    tv.tv_usec = 0;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    return ok;
+}
+
+}  /* namespace SocksPeerConnector */
+
+#endif /* SQUID_SRC_SOCKS_PEER_CONNECTOR_H */

--- a/squid_patch/src/SocksPeerConnector.h
+++ b/squid_patch/src/SocksPeerConnector.h
@@ -181,10 +181,11 @@ static inline bool socks5Connect(int fd,
         if (aResp[0] != 0x01 || aResp[1] != 0x00)
             return false;   /* auth failed or wrong sub-negotiation version */
 
-    } else if (gResp[1] == 0xFF) {
-        return false;       /* no acceptable method */
+    } else if (gResp[1] == 0x00) {
+        /* no auth required */
+    } else {
+        return false;       /* unsupported or unacceptable method (includes 0xFF) */
     }
-    /* else gResp[1] == 0x00 → no auth required */
 
     /* --- connect request --------------------------------------------- */
     uint8_t connReq[263];
@@ -286,15 +287,20 @@ static inline bool negotiate(int fd, SocksPeerType type,
     /* save original timeouts and set a 10 s limit for the handshake */
     struct timeval origRecvTv = {0, 0}, origSendTv = {0, 0};
     socklen_t tvLen = sizeof(struct timeval);
-    getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &origRecvTv, &tvLen);
-    tvLen = sizeof(struct timeval);
-    getsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &origSendTv, &tvLen);
+    if (getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &origRecvTv, &tvLen) < 0 ||
+        getsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &origSendTv, &tvLen) < 0) {
+        fcntl(fd, F_SETFL, flags);
+        return false;
+    }
 
     struct timeval tv;
     tv.tv_sec  = 10;
     tv.tv_usec = 0;
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0 ||
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+        fcntl(fd, F_SETFL, flags);
+        return false;
+    }
 
     bool ok = false;
     if (type == SOCKS_V4)
@@ -302,10 +308,13 @@ static inline bool negotiate(int fd, SocksPeerType type,
     else if (type == SOCKS_V5)
         ok = socks5Connect(fd, targetHost, targetPort, user, pass);
 
-    /* restore original flags and timeouts */
-    fcntl(fd, F_SETFL, flags);
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &origRecvTv, sizeof(origRecvTv));
-    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &origSendTv, sizeof(origSendTv));
+    /* restore original flags and timeouts (best-effort, log-worthy but not fatal) */
+    int restoreOk = 0;
+    restoreOk |= fcntl(fd, F_SETFL, flags);
+    restoreOk |= setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &origRecvTv, sizeof(origRecvTv));
+    restoreOk |= setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &origSendTv, sizeof(origSendTv));
+    if (restoreOk < 0 && ok)
+        return false;   /* negotiation succeeded but socket is in bad state */
 
     return ok;
 }

--- a/squid_patch/src/SocksPeerConnector.h
+++ b/squid_patch/src/SocksPeerConnector.h
@@ -127,20 +127,15 @@ static inline bool socks5Connect(int fd,
     const bool hasAuth = (!user.empty() && !pass.empty());
 
     /* --- greeting ---------------------------------------------------- */
-    uint8_t greeting[4];
-    size_t gLen;
-    if (hasAuth) {
-        greeting[0] = 0x05;   /* VER                     */
-        greeting[1] = 0x02;   /* NMETHODS                */
-        greeting[2] = 0x00;   /* NO AUTHENTICATION       */
-        greeting[3] = 0x02;   /* USERNAME / PASSWORD      */
-        gLen = 4;
-    } else {
-        greeting[0] = 0x05;
-        greeting[1] = 0x01;
-        greeting[2] = 0x00;
-        gLen = 3;
-    }
+    /* When credentials are configured, advertise ONLY USER/PASS to
+     * prevent a rogue SOCKS5 server from silently downgrading to
+     * "no authentication" and accepting traffic without verifying
+     * the credentials the operator explicitly provided. */
+    uint8_t greeting[3];
+    greeting[0] = 0x05;       /* VER      */
+    greeting[1] = 0x01;       /* NMETHODS */
+    greeting[2] = hasAuth ? 0x02 : 0x00;  /* USER/PASS or NO AUTH */
+    const size_t gLen = 3;
 
     if (!syncSend(fd, greeting, gLen))
         return false;
@@ -182,7 +177,11 @@ static inline bool socks5Connect(int fd,
             return false;   /* auth failed or wrong sub-negotiation version */
 
     } else if (gResp[1] == 0x00) {
-        /* no auth required */
+        /* Server chose "no authentication". Only accept this when the
+         * operator did NOT configure credentials; otherwise the server
+         * is downgrading away from the authentication we required. */
+        if (hasAuth)
+            return false;
     } else {
         return false;       /* unsupported or unacceptable method (includes 0xFF) */
     }

--- a/squid_patch/src/SocksPeerConnector.h
+++ b/squid_patch/src/SocksPeerConnector.h
@@ -146,6 +146,10 @@ static inline bool socks5Connect(int fd,
         if (!hasAuth)
             return false;
 
+        /* RFC 1929: username and password are each max 255 bytes */
+        if (user.length() > 255 || pass.length() > 255)
+            return false;
+
         uint8_t auth[515];
         size_t aPos = 0;
         auth[aPos++] = 0x01;  /* sub-negotiation VER */

--- a/squid_patch/src/SocksPeerConnector.h
+++ b/squid_patch/src/SocksPeerConnector.h
@@ -38,8 +38,11 @@ static inline bool syncSend(int fd, const void *buf, size_t len)
     size_t sent = 0;
     while (sent < len) {
         ssize_t n = ::send(fd, p + sent, len - sent, MSG_NOSIGNAL);
-        if (n <= 0)
+        if (n < 0) {
+            if (errno == EINTR) continue;
             return false;
+        }
+        if (n == 0) return false;
         sent += static_cast<size_t>(n);
     }
     return true;
@@ -51,8 +54,11 @@ static inline bool syncRecv(int fd, void *buf, size_t len)
     size_t got = 0;
     while (got < len) {
         ssize_t n = ::recv(fd, p + got, len - got, 0);
-        if (n <= 0)
+        if (n < 0) {
+            if (errno == EINTR) continue;
             return false;
+        }
+        if (n == 0) return false;
         got += static_cast<size_t>(n);
     }
     return true;
@@ -172,8 +178,8 @@ static inline bool socks5Connect(int fd,
         if (!syncRecv(fd, aResp, 2))
             return false;
 
-        if (aResp[1] != 0x00)
-            return false;   /* auth failed */
+        if (aResp[0] != 0x01 || aResp[1] != 0x00)
+            return false;   /* auth failed or wrong sub-negotiation version */
 
     } else if (gResp[1] == 0xFF) {
         return false;       /* no acceptable method */
@@ -277,7 +283,13 @@ static inline bool negotiate(int fd, SocksPeerType type,
     if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0)
         return false;
 
-    /* set a 10 s timeout so we don't hang forever */
+    /* save original timeouts and set a 10 s limit for the handshake */
+    struct timeval origRecvTv = {0, 0}, origSendTv = {0, 0};
+    socklen_t tvLen = sizeof(struct timeval);
+    getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &origRecvTv, &tvLen);
+    tvLen = sizeof(struct timeval);
+    getsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &origSendTv, &tvLen);
+
     struct timeval tv;
     tv.tv_sec  = 10;
     tv.tv_usec = 0;
@@ -290,12 +302,10 @@ static inline bool negotiate(int fd, SocksPeerType type,
     else if (type == SOCKS_V5)
         ok = socks5Connect(fd, targetHost, targetPort, user, pass);
 
-    /* restore non-blocking + clear timeouts */
+    /* restore original flags and timeouts */
     fcntl(fd, F_SETFL, flags);
-    tv.tv_sec = 0;
-    tv.tv_usec = 0;
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &origRecvTv, sizeof(origRecvTv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &origSendTv, sizeof(origSendTv));
 
     return ok;
 }

--- a/squid_patch/src/SocksPeerConnector.h
+++ b/squid_patch/src/SocksPeerConnector.h
@@ -72,7 +72,12 @@ static inline bool socks4Connect(int fd,
         addr.s_addr = htonl(0x00000001);
     }
 
+    /* Bounds check: 8 (header) + userid + 1 (null) + hostname + 1 (null) */
+    const size_t needed = 8 + user.size() + 1 + (useSocks4a ? host.size() + 1 : 0);
     uint8_t req[600];
+    if (needed > sizeof(req))
+        return false;
+
     size_t pos = 0;
 
     req[pos++] = 0x04;                          /* VN  = 4             */
@@ -182,10 +187,27 @@ static inline bool socks5Connect(int fd,
     connReq[cPos++] = 0x05;   /* VER                  */
     connReq[cPos++] = 0x01;   /* CMD = CONNECT        */
     connReq[cPos++] = 0x00;   /* RSV                  */
-    connReq[cPos++] = 0x03;   /* ATYP = DOMAINNAME    */
-    connReq[cPos++] = static_cast<uint8_t>(host.length());
-    std::memcpy(connReq + cPos, host.c_str(), host.length());
-    cPos += host.length();
+
+    /* Detect address type: IPv4, IPv6, or domain name */
+    struct in_addr ipv4;
+    struct in6_addr ipv6;
+    if (inet_pton(AF_INET, host.c_str(), &ipv4) == 1) {
+        connReq[cPos++] = 0x01;   /* ATYP = IPv4 */
+        std::memcpy(connReq + cPos, &ipv4, sizeof(ipv4));
+        cPos += sizeof(ipv4);
+    } else if (inet_pton(AF_INET6, host.c_str(), &ipv6) == 1) {
+        connReq[cPos++] = 0x04;   /* ATYP = IPv6 */
+        std::memcpy(connReq + cPos, &ipv6, sizeof(ipv6));
+        cPos += sizeof(ipv6);
+    } else {
+        if (host.length() > 255)
+            return false;
+        connReq[cPos++] = 0x03;   /* ATYP = DOMAINNAME    */
+        connReq[cPos++] = static_cast<uint8_t>(host.length());
+        std::memcpy(connReq + cPos, host.c_str(), host.length());
+        cPos += host.length();
+    }
+
     connReq[cPos++] = static_cast<uint8_t>((port >> 8) & 0xFF);
     connReq[cPos++] = static_cast<uint8_t>(port & 0xFF);
 

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -3,7 +3,10 @@ services:
   squid:
     ports:
       - 3128:3128
-    image: b4tman/squid:5.8
+    build:
+      context: ./squid_patch
+      dockerfile: Dockerfile
+    image: squid-socks:6.10
     volumes:
       - './config:/etc/squid/conf.d:ro'
     container_name: dockersquid_rotate
@@ -12,7 +15,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: [ "CMD-SHELL", "export https_proxy=127.0.0.1:3128 && export http_proxy=127.0.0.1:3128 && wget -q -Y on  -O - http://httpbin.org/ip || exit 1" ]
+      test: [ "CMD-SHELL", "export https_proxy=127.0.0.1:3128 && export http_proxy=127.0.0.1:3128 && curl -sf -o /dev/null http://httpbin.org/ip || exit 1" ]
       retries: 5
       timeout: "10s"
       start_period: "60s"


### PR DESCRIPTION
## Summary

This PR adds native SOCKS4/SOCKS5 proxy support directly to Squid via cache_peer directives, eliminating the need for intermediate Gost containers. The implementation includes a custom Squid 6.10 build with patches that enable SOCKS negotiation for both HTTP and HTTPS tunneling through cache peers.

## Key Changes

- **SocksPeerConnector.h** (new): Implements synchronous SOCKS4/SOCKS4a and SOCKS5 (RFC 1928/1929) protocol negotiation with support for username/password authentication. Handles blocking socket operations with 10-second timeout.

- **patch_apply.sh** (new): Automated patching script that modifies Squid source to:
  - Add `socks_type`, `socks_user`, `socks_pass` fields to `CachePeer` struct
  - Parse `socks4`, `socks5`, `socks-user=`, `socks-pass=` cache_peer options in `cache_cf.cc`
  - Inject SOCKS negotiation hooks in `FwdState.cc` (HTTP requests) and `tunnel.cc` (HTTPS CONNECT tunneling)

- **Dockerfile** (new): Multi-stage build for custom Squid 6.10 with SOCKS patches applied, replacing the generic b4tman/squid:5.8 image.

- **docker-entrypoint.sh** (new): Squid container startup script with cache initialization and proper permission handling.

- **generate.php** (modified): Updated proxy list generator to:
  - Detect `socks4` and `socks5` scheme types
  - Generate native cache_peer directives with `originserver` flag (since SOCKS tunnel acts as direct connection)
  - Skip Gost container creation for SOCKS proxies (only HTTP proxies need Gost)

- **docker-compose.yml** (modified): Updated to build custom Squid image instead of using pre-built image.

- **GitHub Actions workflow** (new): Comprehensive CI/CD pipeline including:
  - Squid image build and verification
  - Config parsing tests for SOCKS4/SOCKS5 options
  - End-to-end tests with microsocks SOCKS5 server (with and without authentication)
  - Config generator validation

## Implementation Details

- SOCKS negotiation is performed synchronously on the established TCP connection before dispatching HTTP requests or CONNECT tunnels
- Socket is temporarily switched to blocking mode with 10-second timeout during handshake, then restored to original state
- SOCKS4a support for hostname resolution by proxy (when IP parsing fails)
- SOCKS5 supports both no-auth and username/password authentication (RFC 1929)
- After successful SOCKS negotiation, the connection acts as a direct tunnel to the target, so `originserver` flag is required in cache_peer config
- Pattern-based sed modifications in patch script tolerate minor whitespace variations across Squid point releases

https://claude.ai/code/session_01Tfy3kPd51qRgxpCFXjb2g9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Squid が SOCKS4/SOCKS5 の cache_peer 経由で直接接続できるようになりました。
  * カスタム Squid ランタイムイメージ（squid-socks:6.10）を追加しました。

* **改善**
  * コンテナ起動時のエントリポイントとキャッシュ初期化を強化しました。
  * 生成スクリプトが SOCKS 設定と認証情報を正しく出力するようになりました。

* **テスト／CI**
  * ビルド、設定検証、認証あり/なしを含む E2E を実行する自動ワークフローを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->