### PR TITLE
Fix SOCKS connection pooling and authentication handling

### DIFF
--- a/setup/generate.php
+++ b/setup/generate.php
@@ -81,12 +81,17 @@ while ($line = fgets($proxies)){
     elseif(in_array($proxyInfo['scheme'], ['socks4', 'socks5'], true)){
         // Native SOCKS support via Squid cache_peer patch (no Gost needed)
         $socksOpt = $proxyInfo['scheme'];  // "socks4" or "socks5"
-        if ($proxyInfo['user'] && $proxyInfo['pass']) {
+        // socks-user/socks-pass are only valid with socks5 (RFC1929).
+        // The Squid patch rejects them on socks4, so emitting them there
+        // would break config parsing.  Skip and warn for socks4 entries.
+        if ($proxyInfo['scheme'] === 'socks5' && $proxyInfo['user'] && $proxyInfo['pass']) {
             // SOCKS5 RFC1929 uses raw username/password; do not URL-encode.
             $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
                 $proxyInfo['user'],
                 $proxyInfo['pass']
             );
+        } elseif ($proxyInfo['scheme'] === 'socks4' && ($proxyInfo['user'] || $proxyInfo['pass'])) {
+            fwrite(STDERR, "Note: SOCKS4 credentials ignored (use socks5 for auth): " . $proxyInfo['host'] . PHP_EOL);
         }
         $squid_conf[] = sprintf($squid_socks,
             $proxyInfo['host'],

--- a/setup/generate.php
+++ b/setup/generate.php
@@ -84,13 +84,24 @@ while ($line = fgets($proxies)){
         // socks-user/socks-pass are only valid with socks5 (RFC1929).
         // The Squid patch rejects them on socks4, so emitting them there
         // would break config parsing.  Skip and warn for socks4 entries.
-        if ($proxyInfo['scheme'] === 'socks5' && $proxyInfo['user'] && $proxyInfo['pass']) {
-            // SOCKS5 RFC1929 uses raw username/password; do not URL-encode.
-            $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
-                $proxyInfo['user'],
-                $proxyInfo['pass']
-            );
-        } elseif ($proxyInfo['scheme'] === 'socks4' && ($proxyInfo['user'] || $proxyInfo['pass'])) {
+        // Use !== '' rather than truthy checks so values like '0' are
+        // treated as valid credentials, and so a half-filled pair does
+        // not silently fall back to no-auth.
+        $hasUser = ($proxyInfo['user'] !== '');
+        $hasPass = ($proxyInfo['pass'] !== '');
+        if ($proxyInfo['scheme'] === 'socks5') {
+            if ($hasUser xor $hasPass) {
+                fwrite(STDERR, "Skipping SOCKS5 proxy with incomplete credentials: " . $proxyInfo['host'] . PHP_EOL);
+                continue;
+            }
+            if ($hasUser && $hasPass) {
+                // SOCKS5 RFC1929 uses raw username/password; do not URL-encode.
+                $socksOpt .= sprintf(' socks-user=%s socks-pass=%s',
+                    $proxyInfo['user'],
+                    $proxyInfo['pass']
+                );
+            }
+        } elseif ($proxyInfo['scheme'] === 'socks4' && ($hasUser || $hasPass)) {
             fwrite(STDERR, "Note: SOCKS4 credentials ignored (use socks5 for auth): " . $proxyInfo['host'] . PHP_EOL);
         }
         $squid_conf[] = sprintf($squid_socks,

--- a/squid_patch/patch_apply.sh
+++ b/squid_patch/patch_apply.sh
@@ -210,6 +210,15 @@ socks_hook = r'''
     /* SOCKS peer negotiation: after TCP connect, before HTTP dispatch */
     if (const auto sp = serverConnection()->getPeer()) {
         if (sp->socks_type) {
+            /* The SOCKS tunnel is bound to (request->url.host():port).
+             * The pconn pool is keyed by peer address, NOT target, so a
+             * pooled SOCKS-negotiated connection would silently route the
+             * next request to the WRONG destination.  Force the upstream
+             * connection to close after this request to keep one tunnel
+             * per target, and to guarantee the next dispatch() runs on a
+             * freshly-connected fd that has not been SOCKS-negotiated yet. */
+            request->flags.proxyKeepalive = false;
+
             const auto targetPort = static_cast<uint16_t>(request->url.port());
             debugs(17, 3, "SOCKS" << sp->socks_type
                    << " negotiation with peer " << sp->host
@@ -290,6 +299,11 @@ socks_tunnel_hook = r'''
     /* SOCKS peer: negotiate tunnel right after TCP connect */
     if (conn->getPeer() && conn->getPeer()->socks_type) {
         const auto sp = conn->getPeer();
+        /* Same rationale as FwdState::dispatch(): the SOCKS tunnel is
+         * bound to one target host, so prevent this connection from being
+         * returned to the pconn pool where another request could pick it
+         * up and silently send data into the previous target's tunnel. */
+        request->flags.proxyKeepalive = false;
         const auto targetPort = static_cast<uint16_t>(request->url.port());
         debugs(26, 3, "SOCKS" << sp->socks_type
                << " tunnel negotiation with peer " << sp->host


### PR DESCRIPTION
## Summary
This PR addresses two issues with SOCKS proxy support: improper connection reuse that could route requests to wrong destinations, and incorrect authentication credential handling for SOCKS4 vs SOCKS5.

## Key Changes

- **Connection pooling fix**: Disable HTTP keep-alive (`proxyKeepalive = false`) for SOCKS-negotiated connections in both `FwdState::dispatch()` and tunnel negotiation paths. This prevents pooled connections from being reused for different target hosts, which would silently route subsequent requests through the wrong SOCKS tunnel.

- **SOCKS authentication validation**: Updated configuration generation to only emit `socks-user` and `socks-pass` options for SOCKS5 connections, as these credentials are only valid under RFC1929 (SOCKS5 authentication). SOCKS4 entries with credentials now trigger a warning message instead of generating invalid configuration.

## Implementation Details

- The SOCKS tunnel is bound to a specific target host:port combination, but the connection pool is keyed by peer address only. Without disabling keep-alive, a subsequent request could reuse a pooled connection and inadvertently send data through the previous target's tunnel.

- SOCKS4 does not support username/password authentication per its specification, so the Squid patch correctly rejects these options. The PHP configuration generator now respects this limitation and warns users to use SOCKS5 if authentication is needed.

https://claude.ai/code/session_01Cz4tkSZKDhTPnBx8YsYoyg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* SOCKS プロキシの認証処理を改善しました。SOCKS5 では、ユーザー名とパスワードが両方設定されている場合にのみ認証情報を使用するようになります。
* SOCKS4 では、提供された認証情報が適切に無視されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->